### PR TITLE
Change PWD to "." in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,6 @@ services:
       - "8080:80"
     volumes:
       - ./projects:/data  # map data dir to host
-      - ${PWD}/nginx.conf:/etc/nginx/conf.d/default.conf
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf
     networks:
       - merginmaps


### PR DESCRIPTION
docker-compose struggles with PWD sometimes, especially when the command is not run from a shell (e.g. via systemd or via ansible). This commit uses a more idiomatic relative path in the compose file, fixing these issues.