### PR TITLE
Prevent show access requests for workspaces guest

### DIFF
--- a/web-app/packages/admin-lib/src/modules/project/views/ProjectSettingsView.vue
+++ b/web-app/packages/admin-lib/src/modules/project/views/ProjectSettingsView.vue
@@ -10,6 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
     :projectName="projectName"
     :asAdmin="asAdmin"
     :show-settings="true"
+    :show-access-requests="true"
   >
     <!-- TODO: V3_UPGRADE [MERGIN-EXT] - change settingsAccess to settings.access  -->
     <template #permissions="{ settings, keyProp, saveProject }">

--- a/web-app/packages/app/src/modules/project/views/ProjectSettingsView.vue
+++ b/web-app/packages/app/src/modules/project/views/ProjectSettingsView.vue
@@ -10,6 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
     :projectName="projectName"
     :asAdmin="asAdmin"
     :show-settings="projectStore.isProjectOwner"
+    :show-access-requests="userStore.isGlobalWorkspaceAdmin"
   >
     <!-- TODO: V3_UPGRADE [MERGIN-EXT] - change settingsAccess to settings.access  -->
     <template #permissions="{ settings, keyProp, saveProject }">
@@ -26,7 +27,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 import {
   ProjectSettingsViewTemplate,
   ProjectPermissionsTemplate,
-  useProjectStore
+  useProjectStore,
+  useUserStore
 } from '@mergin/lib'
 import { defineComponent } from 'vue'
 
@@ -46,9 +48,11 @@ export default defineComponent({
   },
   setup(_props) {
     const projectStore = useProjectStore()
+    const userStore = useUserStore()
 
     return {
-      projectStore
+      projectStore,
+      userStore
     }
   }
 })

--- a/web-app/packages/lib/src/modules/project/views/ProjectSettingsViewTemplate.vue
+++ b/web-app/packages/lib/src/modules/project/views/ProjectSettingsViewTemplate.vue
@@ -12,7 +12,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
       :key-prop="key"
       :save-project="saveProject"
     ></slot>
-    <project-access-requests />
+    <project-access-requests v-if="showAccessRequests" />
     <v-layout class="public-private-zone">
       <v-container>
         <v-row>
@@ -65,7 +65,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 <script lang="ts">
 import debounce from 'lodash/debounce'
 import { mapActions, mapState } from 'pinia'
-import { defineComponent } from 'vue'
+import { PropType, defineComponent } from 'vue'
 
 import { getErrorMessage } from '@/common/error_utils'
 import ConfirmDialog from '@/modules/dialog/components/ConfirmDialog.vue'
@@ -87,7 +87,11 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
-    showSettings: Boolean
+    showSettings: Boolean,
+    showAccessRequests: {
+      type: Boolean as PropType<boolean>,
+      default: false
+    }
   },
   data() {
     return {


### PR DESCRIPTION
**Description**

- prop for showing projects access requests table (default: false) in project settings
- show access requests is based on global admin

State for user which is owner of project but guest in WS

![image](https://github.com/MerginMaps/server/assets/12643115/e3afe6da-1105-4d33-8c03-2565c7cd26e4)
