### PR TITLE
Prepare 2023.6.1 release + env var adjustments

### DIFF
--- a/.prod.env
+++ b/.prod.env
@@ -8,8 +8,8 @@ CONTACT_EMAIL=fixme
 
 #DEBUG=FLASK_DEBUG | False
 
-#LOCAL_PROJECTS=os.path.join(config_dir, os.pardir, os.pardir, 'projects')  # for local storage type
-LOCAL_PROJECTS=/data/live
+#LOCAL_PROJECTS=/data/live
+LOCAL_PROJECTS=os.path.join(config_dir, os.pardir, os.pardir, 'projects')  # for local storage type
 
 #MAINTENANCE_FILE=os.path.join(LOCAL_PROJECTS, 'MAINTENANCE')  # locking file when backups are created
 MAINTENANCE_FILE=/data/MAINTENANCE
@@ -23,8 +23,8 @@ SECRET_KEY=fixme
 
 #SWAGGER_UI=False  # to enable swagger UI console (for test only)
 
-#TEMP_DIR=gettempdir()  # trash dir for temp files being cleaned regularly
-TEMP_DIR=/data/tmp
+#TEMP_DIR=/data/tmp
+TEMP_DIR=gettempdir()  # trash dir for temp files being cleaned regularly
 
 #TESTING=False
 
@@ -154,8 +154,7 @@ CLOSED_ACCOUNT_EXPIRATION=1
 # GLOBAL_STORAGE 1024 * 1024 * 1024
 GLOBAL_STORAGE=10737418240
 
-# GLOBAL_READ False
-GLOBAL_READ=1
+# GLOBAL_READ False - Everyone will be "guest", you need to share projects with them explicitly
 
 # GLOBAL_WRITE False
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     networks:
       - merginmaps
   server:
-    image: lutraconsulting/merginmaps-backend:2023.2.0
+    image: lutraconsulting/merginmaps-backend:2023.6.1
     container_name: merginmaps-server
     restart: always
     user: 901:999
@@ -35,7 +35,7 @@ services:
     networks:
       - merginmaps
   web:
-    image: lutraconsulting/merginmaps-frontend:2023.2.0
+    image: lutraconsulting/merginmaps-frontend:2023.6.1
     container_name: merginmaps-web
     restart: always
     depends_on:

--- a/server/mergin/version.py
+++ b/server/mergin/version.py
@@ -4,4 +4,4 @@
 
 
 def get_version():
-    return "2023.3.0"
+    return "2023.6.1"

--- a/server/setup.py
+++ b/server/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="mergin",
-    version="2023.3.0",
+    version="2023.6.1",
     url="https://github.com/MerginMaps/mergin",
     license="AGPL-3.0-only",
     author="Lutra Consulting Limited",


### PR DESCRIPTION
- Updates versions to 2023.6.1
- Alters default values of path variables so that it works when deployed locally
- **Changed default permissions to guest** as it was creating confusion and security questions, see https://github.com/MerginMaps/server/issues/131