### PR TITLE
Add build hash variable

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,6 +6,9 @@ MAINTAINER Martin Varga "martin.varga@lutraconsulting.co.uk"
 ENV TZ=Europe/London
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
+ARG BUILD_HASH="unknown"
+ENV BUILD_HASH=${BUILD_HASH}
+
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends\
     musl-dev \

--- a/server/application.py
+++ b/server/application.py
@@ -29,7 +29,12 @@ from mergin.stats.app import register as register_stats
 Configuration.SERVER_TYPE = "ce"
 Configuration.USER_SELF_REGISTRATION = False
 application = create_app(
-    ["DOCS_URL", "SERVER_TYPE", "COLLECT_STATISTICS", "USER_SELF_REGISTRATION"]
+    [
+        "DOCS_URL",
+        "SERVER_TYPE",
+        "COLLECT_STATISTICS",
+        "USER_SELF_REGISTRATION",
+    ]
 )
 register_stats(application)
 # patch celery object with application settings and attach flask context to it

--- a/server/mergin/config.py
+++ b/server/mergin/config.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 
 import os
-from .version import get_version, get_git_hash
+from .version import get_version
 from decouple import config, Csv
 
 config_dir = os.path.abspath(os.path.dirname(__file__))
@@ -93,5 +93,5 @@ class Configuration(object):
     SERVER_TYPE = config("SERVER_TYPE", default="")
     # can users create their own account or is it reserved for superuser only
     USER_SELF_REGISTRATION = config("USER_SELF_REGISTRATION", default=False, cast=bool)
-    # last commit hash number
-    BUILD_HASH = config("BUILD_NUMBER", default=get_git_hash())
+    # build hash number
+    BUILD_HASH = config("BUILD_HASH", default="")

--- a/server/mergin/tests/fixtures.py
+++ b/server/mergin/tests/fixtures.py
@@ -31,7 +31,12 @@ def flask_app(request):
     from ..sync.db_events import remove_events
 
     application = create_app(
-        ["SERVER_TYPE", "DOCS_URL", "COLLECT_STATISTICS", "USER_SELF_REGISTRATION"]
+        [
+            "SERVER_TYPE",
+            "DOCS_URL",
+            "COLLECT_STATISTICS",
+            "USER_SELF_REGISTRATION",
+        ]
     )
     register(application)
     application.config["TEST_DIR"] = os.path.join(thisdir, "test_projects")

--- a/server/mergin/tests/test_config.py
+++ b/server/mergin/tests/test_config.py
@@ -37,3 +37,8 @@ def test_config(client):
     resp = client.get("/config")
     assert resp.json["server_configured"] is True
     assert resp.json["user_self_registration"] is False
+
+    assert resp.json["build_hash"] == ""
+    client.application.config["BUILD_HASH"] = "abcd1234"
+    resp = client.get("/config")
+    assert resp.json["build_hash"] == "abcd1234"

--- a/server/mergin/version.py
+++ b/server/mergin/version.py
@@ -5,13 +5,3 @@
 
 def get_version():
     return "2023.3.0"
-
-
-def get_git_hash():
-    import subprocess
-
-    return (
-        subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
-        .decode("ascii")
-        .strip()
-    )


### PR DESCRIPTION
[Issue](https://github.com/MerginMaps/MerginMaps-Cloud-TEST/issues/144)

In this PR the new `BUILD_HASH` variable is put in `/config`. It gets the correct value during the build, see [GitLab CE part](https://gitlab.lutraconsulting.co.uk/mergin/mergin-ce/-/merge_requests/17)
