### PR TITLE
unique project version for a project

### DIFF
--- a/server/mergin/sync/models.py
+++ b/server/mergin/sync/models.py
@@ -422,6 +422,7 @@ class ProjectVersion(db.Model):
         "Project",
         uselist=False,
     )
+    __table_args__ = (db.UniqueConstraint("project_id", "name"),)
 
     def __init__(self, project, name, author, changes, files, ip, user_agent=None):
         self.project_id = project.id

--- a/server/mergin/tests/test_project_controller.py
+++ b/server/mergin/tests/test_project_controller.py
@@ -2238,10 +2238,10 @@ def test_project_version_integrity(client):
     # try to finish the transaction
     resp = client.post("/v1/project/push/finish/{}".format(upload.id))
     assert resp.status_code == 422
-    assert resp.json["detail"] == "Version conflict. Please try later."
+    assert "Failed to create new version" in resp.json["detail"]
     failure = SyncFailuresHistory.query.filter_by(project_id=upload.project.id).first()
     assert failure.error_type == "push_finish"
-    assert failure.error_details == "Version conflict. Please try later."
+    assert "Failed to create new version" in failure.error_details
     db.session.delete(pv)
     db.session.delete(failure)
     db.session.commit()
@@ -2264,12 +2264,12 @@ def test_project_version_integrity(client):
             headers=json_headers,
         )
         assert resp.status_code == 422
-        assert resp.json["detail"] == "Version conflict. Please try later."
+        assert "Failed to upload a new project version" in resp.json["detail"]
         failure = SyncFailuresHistory.query.filter_by(
             project_id=upload.project.id
         ).first()
         assert failure.error_type == "push_start"
-        assert failure.error_details == "Version conflict. Please try later."
+        assert "Failed to upload a new project version" in failure.error_details
         db.session.delete(pv)
         db.session.commit()
 

--- a/server/mergin/tests/test_project_controller.py
+++ b/server/mergin/tests/test_project_controller.py
@@ -2201,3 +2201,81 @@ def test_get_project_version(client, diff_project):
     # invalid project identifier
     resp = client.get(f"/v1/project/version/1234/v10")
     assert resp.status_code == 404
+
+
+def add_project_version(project, changes, version=2):
+    pv = ProjectVersion(
+        project,
+        f"v{version}",
+        "mergin",
+        changes,
+        project.files,
+        "123",
+    )
+    db.session.add(pv)
+    db.session.commit()
+    return pv
+
+
+def test_project_version_integrity(client):
+    # changes with an upload
+    # create transaction and upload chunks
+    changes = _get_changes_with_diff(test_project_dir)
+    upload, upload_dir = create_transaction("mergin", changes)
+    upload_chunks(upload_dir, upload.changes)
+    # manually create an identical project version in db
+    next_version = "v{}".format(upload.version + 1)
+    pv = ProjectVersion(
+        upload.project,
+        next_version,
+        "mergin",
+        changes,
+        upload.project.files,
+        "123",
+    )
+    db.session.add(pv)
+    db.session.commit()
+    # try to finish the transaction
+    resp = client.post("/v1/project/push/finish/{}".format(upload.id))
+    assert resp.status_code == 422
+    assert resp.json["detail"] == "Version conflict. Please try later."
+    failure = SyncFailuresHistory.query.filter_by(project_id=upload.project.id).first()
+    assert failure.error_type == "push_finish"
+    assert failure.error_details == "Version conflict. Please try later."
+    db.session.delete(pv)
+    db.session.delete(failure)
+    db.session.commit()
+
+    # changes without an upload
+    # to insert an identical project version when no upload (only one endpoint used),
+    # we need to pretend side effect of a function called just before project version insertion
+    with patch("mergin.sync.utils.get_user_agent") as mock:
+        project = Project.query.filter_by(
+            name=test_project, workspace_id=test_workspace_id
+        ).first()
+        url = "/v1/project/push/{}/{}".format(test_workspace_name, test_project)
+        changes = _get_changes(test_project_dir)
+        changes["added"] = changes["updated"] = []  # only deleted files
+        data = {"version": "v1", "changes": changes}
+        pv = mock.side_effect = add_project_version(project, changes)
+        resp = client.post(
+            url,
+            data=json.dumps(data, cls=DateTimeEncoder).encode("utf-8"),
+            headers=json_headers,
+        )
+        assert resp.status_code == 422
+        assert resp.json["detail"] == "Version conflict. Please try later."
+        failure = SyncFailuresHistory.query.filter_by(
+            project_id=upload.project.id
+        ).first()
+        assert failure.error_type == "push_start"
+        assert failure.error_details == "Version conflict. Please try later."
+        db.session.delete(pv)
+        db.session.commit()
+
+    # check infrastructure is clean for successful push if no version conflict occur
+    changes = _get_changes(test_project_dir)
+    upload, upload_dir = create_transaction("mergin", changes)
+    upload_chunks(upload_dir, upload.changes)
+    resp = client.post("/v1/project/push/finish/{}".format(upload.id))
+    assert resp.status_code == 200

--- a/server/migrations/community/90ee95d638f1_project_version_unique.py
+++ b/server/migrations/community/90ee95d638f1_project_version_unique.py
@@ -1,0 +1,27 @@
+"""project_version_unique
+
+Revision ID: 90ee95d638f1
+Revises: 6bd17a6b8707
+Create Date: 2024-02-23 08:46:22.087477
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "90ee95d638f1"
+down_revision = "6bd17a6b8707"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_unique_constraint(
+        "uq_project_id_version", "project_version", ["project_id", "name"]
+    )
+
+
+def downgrade():
+    op.drop_constraint(op.f("uq_project_id_version"), "project_version", type_="unique")


### PR DESCRIPTION
[Task description](https://github.com/MerginMaps/MerginMaps-Cloud-TEST/issues/173)

Add unique constraint for project_id and version name in project version table.

Catch attempts for breaking the constraint.

Improve push logging.