### PR TITLE
make revision id sequence continuous

### DIFF
--- a/server/migrations/community/1fcbea2a0f2c_drop_namespace_related_objects.py
+++ b/server/migrations/community/1fcbea2a0f2c_drop_namespace_related_objects.py
@@ -5,7 +5,7 @@
 """Drop namespace related objects
 
 Revision ID: 1fcbea2a0f2c
-Revises: 0ab6a1fbf974
+Revises: 35af0c8be41e
 Create Date: 2022-12-20 15:38:57.825712
 
 """
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "1fcbea2a0f2c"
-down_revision = "0ab6a1fbf974"
+down_revision = "35af0c8be41e"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Revision ids sequence for CE migration was broken in Dec 2022. After this fix, the sequence is continues again and does not cause confusions.

![Screenshot from 2024-03-12 14-34-47](https://github.com/MerginMaps/server/assets/28006188/a3386e9d-6932-42fe-99c3-673f209e2083)
