### PR TITLE
Allow share project parameter and check GLOBAL_ variables

### DIFF
--- a/server/application.py
+++ b/server/application.py
@@ -34,6 +34,9 @@ application = create_app(
         "SERVER_TYPE",
         "COLLECT_STATISTICS",
         "USER_SELF_REGISTRATION",
+        "GLOBAL_ADMIN",
+        "GLOBAL_READ",
+        "GLOBAL_WRITE"
     ]
 )
 register_stats(application)

--- a/server/application.py
+++ b/server/application.py
@@ -36,7 +36,7 @@ application = create_app(
         "USER_SELF_REGISTRATION",
         "GLOBAL_ADMIN",
         "GLOBAL_READ",
-        "GLOBAL_WRITE"
+        "GLOBAL_WRITE",
     ]
 )
 register_stats(application)

--- a/web-app/packages/app/src/modules/project/views/ProjectCollaboratorsView.vue
+++ b/web-app/packages/app/src/modules/project/views/ProjectCollaboratorsView.vue
@@ -8,6 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
   <project-collaborators-view-template
     v-if="isProjectOwner"
     @share="openShareDialog"
+    :allow-share="!instanceStore.globalRolesEnabled"
     :show-access-requests="userStore.isGlobalWorkspaceAdmin"
   />
 </template>
@@ -18,13 +19,15 @@ import {
   ProjectCollaboratorsViewTemplate,
   useDialogStore,
   useProjectStore,
-  useUserStore
+  useUserStore,
+  useInstanceStore
 } from '@mergin/lib'
 import { computed } from 'vue'
 
 const projectStore = useProjectStore()
 const dialogStore = useDialogStore()
 const userStore = useUserStore()
+const instanceStore = useInstanceStore()
 
 const isProjectOwner = computed(() => projectStore.isProjectOwner)
 

--- a/web-app/packages/app/src/modules/project/views/ProjectsListView.vue
+++ b/web-app/packages/app/src/modules/project/views/ProjectsListView.vue
@@ -16,6 +16,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         :show-namespace="false"
         :namespace="namespace"
         :only-public="onlyPublic"
+        :can-create-project="canCreateProject"
         @new-project-error="onNewProjectError"
       />
     </template>

--- a/web-app/packages/lib/src/common/index.ts
+++ b/web-app/packages/lib/src/common/index.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 
+import { getAvatar } from './mergin_utils'
+
 import {
   formatDate,
   formatDateTime,
@@ -10,7 +12,6 @@ import {
 } from '@/common/date_utils'
 import { formatFileSize, formatToCurrency } from '@/common/number_utils'
 import { formatToTitle } from '@/common/text_utils'
-import { getAvatar } from './mergin_utils'
 
 export * from './components'
 export * from './errors'

--- a/web-app/packages/lib/src/modules/instance/store.ts
+++ b/web-app/packages/lib/src/modules/instance/store.ts
@@ -28,6 +28,19 @@ export const useInstanceStore = defineStore('instanceModule', {
     configData: undefined
   }),
 
+  getters: {
+    /**
+     * Checks if global roles are enabled based on the config data.
+     * Returns true if any of the global role flags are truthy, false otherwise.
+     */
+    globalRolesEnabled(state): boolean {
+      // eslint-disable-next-line camelcase
+      const { global_read, global_write, global_admin } = state.configData
+      // eslint-disable-next-line camelcase
+      return [global_read, global_write, global_admin].some((r) => !!r)
+    }
+  },
+
   actions: {
     setConfigData(payload: ConfigResponse) {
       this.configData = payload

--- a/web-app/packages/lib/src/modules/instance/types.ts
+++ b/web-app/packages/lib/src/modules/instance/types.ts
@@ -22,6 +22,9 @@ export interface BaseConfigResponse {
   major?: number
   minor?: number
   fix?: number
+  global_read?: boolean
+  global_write?: boolean
+  global_admin?: boolean
 }
 
 export type ConfigResponse = BaseConfigResponse &

--- a/web-app/packages/lib/src/modules/layout/components/SideBarTemplate.vue
+++ b/web-app/packages/lib/src/modules/layout/components/SideBarTemplate.vue
@@ -23,8 +23,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
   >
     <div class="flex flex-column justify-content-between h-screen">
       <div>
-        <header class="p-2 lg:p-5 mb-2">
-          <div class="lg:hidden flex justify-content-end">
+        <header class="p-2 xl:p-5 mb-2">
+          <div class="xl:hidden flex justify-content-end">
             <PButton
               plain
               icon="ti ti-x"
@@ -109,7 +109,7 @@ const onCloseClick = () => {
   max-width: 16.66%;
 }
 
-@media screen and (max-width: $lg) {
+@media screen and (max-width: $xl) {
   .sidebar {
     max-width: 400px;
   }

--- a/web-app/packages/lib/src/modules/layout/store.ts
+++ b/web-app/packages/lib/src/modules/layout/store.ts
@@ -17,7 +17,7 @@ const CLOSED_ELEMENTS_KEY = 'mm-closed-elements'
 
 export const useLayoutStore = defineStore('layoutModule', {
   state: (): LayoutState => ({
-    overlayBreakpoint: 992,
+    overlayBreakpoint: 1200,
     drawer: false,
     isUnderOverlayBreakpoint: false,
     closedElements: []

--- a/web-app/packages/lib/src/modules/project/components/ProjectForm.vue
+++ b/web-app/packages/lib/src/modules/project/components/ProjectForm.vue
@@ -60,10 +60,10 @@ import { mapActions, mapState } from 'pinia'
 import { defineComponent } from 'vue'
 
 import { TipMessage } from '@/common/components'
+import { useUserStore } from '@/main'
 import { useDialogStore } from '@/modules/dialog/store'
 import { useFormStore } from '@/modules/form/store'
 import { useProjectStore } from '@/modules/project/store'
-import { useUserStore } from '@/main'
 
 export default defineComponent({
   name: 'new-project-form',

--- a/web-app/packages/lib/src/modules/project/views/ProjectCollaboratorsViewTemplate.vue
+++ b/web-app/packages/lib/src/modules/project/views/ProjectCollaboratorsViewTemplate.vue
@@ -32,6 +32,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             />
           </span>
           <PButton
+            v-if="allowShare"
             @click="$emit('share')"
             icon="ti ti-send"
             label="Share"
@@ -63,9 +64,13 @@ import AppSection from '@/common/components/AppSection.vue'
 import { useUserStore } from '@/main'
 
 defineEmits<{ share: [] }>()
-withDefaults(defineProps<{ showAccessRequests?: boolean }>(), {
-  showAccessRequests: false
-})
+withDefaults(
+  defineProps<{ showAccessRequests?: boolean; allowShare?: boolean }>(),
+  {
+    showAccessRequests: false,
+    allowShare: true
+  }
+)
 
 const projectStore = useProjectStore()
 const userStore = useUserStore()


### PR DESCRIPTION
**Details**

Ticket: https://github.com/MerginMaps/MerginMaps-Cloud-TEST/issues/215

- Make sharing buttons visibility configurable in collaborators tab (allowShare: true props to collaborators)
- If there is one of GLOBAL_* variable true, we will hide share project button.

GLOBAL_READ is enabled:

![image](https://github.com/MerginMaps/server/assets/12643115/8b3bcd8d-3aa2-437b-ba7c-d890a4ffcd19)

There is no GLOBAL_READ/WRITE/ADMIN

![image](https://github.com/MerginMaps/server/assets/12643115/80de42fe-30bc-496a-a129-ee268467a7ba)

:rose: Minor design fixes:

- enh: Laptops - change break point for sidebar overlay to 1200px
