### PR TITLE
Refactor names of font classes

### DIFF
--- a/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/_fonts.scss
+++ b/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/_fonts.scss
@@ -22,4 +22,87 @@ body {
   font-family: Inter, sans-serif;
 }
 
-$fontFamily: Inter, sans-serif
+$fontFamily: Inter, sans-serif;
+
+.headline-h1 {
+  font-size: 3rem !important;
+  line-height: 1.25;
+  font-weight: 600;
+}
+
+.headline-h2 {
+  font-size: 2.25rem !important;
+  line-height: 1.33;
+  font-weight: 600;
+}
+
+.headline-h3 {
+  font-size: 1.5rem !important;
+  line-height: 1.5;
+  font-weight: 600;
+}
+
+.title-t1 {
+  font-size: 1.125rem !important;
+  line-height: 1.6;
+  font-weight: 600;
+}
+
+.title-t2 {
+  font-size: 1rem !important;
+  line-height: 1.75;
+  font-weight: 600;
+}
+
+.title-t3 {
+  font-size: 0.875rem !important;
+  line-height: 1.857;
+  font-weight: 600;
+}
+
+.title-t4 {
+  font-size: 0.75rem !important;
+  line-height: 2;
+  font-weight: 600;
+}
+
+.title-t5 {
+  font-size: 0.625rem !important;
+  line-height: 2.2;
+  font-weight: 600;
+}
+
+.paragraph-p1 {
+  font-size: 2rem !important;
+  line-height: 1.375;
+}
+
+.paragraph-p2 {
+  font-size: 1.5rem !important;
+  line-height: 1.5;
+}
+
+.paragraph-p3 {
+  font-size: 1.25rem !important;
+  line-height: 1.6;
+}
+
+.paragraph-p4 {
+  font-size: 1rem !important;
+  line-height: 1.75;
+}
+
+.paragraph-p5 {
+  font-size: 0.875rem !important;
+  line-height: 1.857;
+}
+
+.paragraph-p6 {
+  font-size: 0.75rem !important;
+  line-height: 2;
+}
+
+.paragraph-p7 {
+  font-size: 0.625rem !important;
+  line-height: 2.2;
+}

--- a/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/variables/_general.scss
+++ b/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/variables/_general.scss
@@ -136,4 +136,4 @@ $scaleSM:0.875;
 
 /// Scale factor of small large size
 /// @group general
-$scaleLG:1.25;
+$scaleLG:1.16;

--- a/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/variables/_misc.scss
+++ b/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/variables/_misc.scss
@@ -28,15 +28,15 @@ $badgeHeight: 1.5rem;
 
 /// Font weight of a badge
 /// @group misc
-$badgeFontWeight: 700;
+$badgeFontWeight: 600;
 
 /// Font size of a badge
 /// @group misc
-$badgeFontSize: .75rem;
+$badgeFontSize: 0.625rem;
 
 /// Padding of a badge
 /// @group misc
-$tagPadding: .4rem .8rem;
+$tagPadding: .1em .8em;
 
 /// Height of a progress bar
 /// @group misc

--- a/web-app/packages/lib/src/common/components/AppCircle.vue
+++ b/web-app/packages/lib/src/common/components/AppCircle.vue
@@ -33,8 +33,8 @@ const severityClass = computed(
 )
 const sizeClasses = computed(
   () =>
-    ({ small: 'circle--small text-xs p-1' }[props.size] ||
-    'w-2rem h-2rem text-base p-2')
+    ({ small: 'circle--small paragraph-p6 p-1' }[props.size] ||
+    'w-2rem h-2rem paragraph-p4 p-2')
 )
 </script>
 

--- a/web-app/packages/lib/src/common/components/AppDropdown.vue
+++ b/web-app/packages/lib/src/common/components/AppDropdown.vue
@@ -21,7 +21,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         }
       },
       input: {
-        class: 'text-xs border-round-xl'
+        class: 'paragraph-p6 border-round-xl'
       },
       item({ context }) {
         return {
@@ -49,13 +49,13 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
           scope.class,
           'ti',
           isOpen ? 'ti-chevron-up' : 'ti-chevron-down',
-          'font-semibold text-base'
+          'font-semibold title-t2'
         ]"
       ></i>
     </template>
     <template #option="{ option }">
-      <div class="flex text-xs align-items-center py-2">
-        <div class="flex flex-column mr-6 gap-2">
+      <div class="flex paragraph-p6 align-items-center py-2">
+        <div class="flex flex-column mr-6 gap-1">
           <p
             :class="[
               option.description && 'font-semibold',

--- a/web-app/packages/lib/src/common/components/AppPanelToggleable.vue
+++ b/web-app/packages/lib/src/common/components/AppPanelToggleable.vue
@@ -31,7 +31,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
       <slot name="header"></slot>
     </template>
     <template v-else-if="$slots.title" #header>
-      <h3 class="text-color-forest font-semibold m-0">
+      <h3 class="text-color-forest font-semibold m-0 title-t3">
         <slot name="title"></slot>
       </h3>
     </template>

--- a/web-app/packages/lib/src/common/components/AppPasswordTooltip.vue
+++ b/web-app/packages/lib/src/common/components/AppPasswordTooltip.vue
@@ -5,10 +5,10 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 -->
 
 <template>
-  <label class="flex align-items-center text-xs" :for="'for'"
+  <label class="flex align-items-center paragraph-p6" :for="'for'"
     ><slot name="label"></slot>&nbsp;
     <i
-      class="ti ti-info-circle-filled cursor-pointer text-color-medium-green hover:text-color text-base"
+      class="ti ti-info-circle-filled cursor-pointer text-color-medium-green hover:text-color paragraph-p4"
       :style="{ color: 'var(--medium-green-color)' }"
       v-tooltip="{
         value: tooltip,

--- a/web-app/packages/lib/src/common/components/AppSection.vue
+++ b/web-app/packages/lib/src/common/components/AppSection.vue
@@ -23,7 +23,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         $slots.title ? 'p-4' : ''
       ]"
     >
-      <h2 v-if="!!$slots.title" class="text-sm text-color">
+      <h2 v-if="!!$slots.title" class="paragraph-p5 text-color">
         <slot name="title"></slot>
       </h2>
       <slot v-else-if="$slots.header" name="header"></slot>

--- a/web-app/packages/lib/src/common/components/AppSectionBanner.vue
+++ b/web-app/packages/lib/src/common/components/AppSectionBanner.vue
@@ -42,11 +42,11 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             <div v-if="$slots['header-image']" class="flex align-items-center">
               <slot name="header-image"></slot>
             </div>
-            <div :class="['flex flex-column gap-3 lg:gap-2']">
-              <h3 class="text-color text-sm font-semibold m-0">
+            <div :class="['flex flex-column gap-2 lg:gap-1']">
+              <h3 class="text-color title-t3">
                 <slot name="title"></slot>
               </h3>
-              <p v-if="$slots.description" class="text-xs m-0 opacity-80">
+              <p v-if="$slots.description" class="paragraph-p6 opacity-80">
                 <slot name="description"></slot>
               </p>
             </div>
@@ -56,7 +56,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
       </template>
       <!-- Header without additional styles -->
       <template v-else #header><slot name="header"></slot></template>
-      <div class="line-height-4"><slot></slot></div>
+      <div><slot></slot></div>
 
       <template v-if="$slots.footer" #footer>
         <slot name="footer"></slot>

--- a/web-app/packages/lib/src/common/components/TipMessage.vue
+++ b/web-app/packages/lib/src/common/components/TipMessage.vue
@@ -15,11 +15,11 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
       </slot>
     </div>
 
-    <div class="text-center md:text-left line-height-4">
-      <p class="tip-message-title text-sm font-semibold m-0 mb-1">
+    <div class="text-center md:text-left">
+      <p class="tip-message-title title-t3 mb-1">
         <slot name="title">Tip from Mergin Maps</slot>
       </p>
-      <p class="opacity-80 text-sm m-0">
+      <p class="opacity-80 paragraph-p5">
         <slot name="description"></slot>
       </p>
     </div>

--- a/web-app/packages/lib/src/mm-theme.ts
+++ b/web-app/packages/lib/src/mm-theme.ts
@@ -4,9 +4,11 @@ import { DataViewPassThroughOptions } from 'primevue/dataview'
 import { DialogPassThroughOptions } from 'primevue/dialog'
 import { InlineMessagePassThroughOptions } from 'primevue/inlinemessage'
 import { InputTextPassThroughOptions } from 'primevue/inputtext'
+import { MenuPassThroughOptions } from 'primevue/menu'
 import { usePassThrough } from 'primevue/passthrough'
 import { PasswordPassThroughOptions } from 'primevue/password'
 import { ProgressBarPassThroughOptions } from 'primevue/progressbar'
+import { TagPassThroughOptions } from 'primevue/tag'
 import { ToastPassThroughOptions } from 'primevue/toast'
 import { TreePassThroughOptions } from 'primevue/tree'
 
@@ -15,17 +17,16 @@ export default usePassThrough(
     button: {
       root(options) {
         return {
-          class: [
-            'line-height-4',
-            options.props.plain ? 'hover:text-color' : undefined
-          ],
-          style:
-            options.context.disabled && !options.props.severity
+          class: [options.props.plain ? 'hover:text-color' : undefined],
+          style: {
+            lineHeight: 1.857,
+            ...(options.context.disabled && !options.props.severity
               ? {
                   backgroundColor: 'var(--medium-green-color)',
                   borderColor: 'var(--medium-green-color)'
                 }
-              : undefined
+              : undefined)
+          }
         }
       }
     } as ButtonPassThroughOptions,
@@ -37,7 +38,7 @@ export default usePassThrough(
         class: 'border-round-xl w-full'
       },
       token: {
-        class: 'text-color-forest text-xs font-semibold',
+        class: 'text-color-forest title-t4',
         style: {
           backgroundColor: 'var(--medium-green-color)'
         }
@@ -97,7 +98,7 @@ export default usePassThrough(
       content(options) {
         return {
           class: [
-            'border-round-xl font-semibold p-2 text-sm',
+            'border-round-xl p-2 title-t3',
             options.context.selected
               ? 'text-white'
               : 'surface-section hover:surface-50'
@@ -121,7 +122,7 @@ export default usePassThrough(
         }
       },
       title: {
-        class: 'text-base font-semibold'
+        class: 'title-t2'
       },
       closeButton:
         'text-2xl hover:surface-ground text-color-forest hover:text-color',
@@ -131,7 +132,14 @@ export default usePassThrough(
       mask: {
         style: { zIndex: 7 }
       }
-    } as DialogPassThroughOptions
+    } as DialogPassThroughOptions,
+    menu: {
+      label: 'title-t4'
+    } as MenuPassThroughOptions,
+    tag: {
+      root: 'title-t5',
+      value: 'title-t5'
+    } as TagPassThroughOptions
   },
   {}
 )

--- a/web-app/packages/lib/src/modules/dashboard/components/DashboardFooter.vue
+++ b/web-app/packages/lib/src/modules/dashboard/components/DashboardFooter.vue
@@ -29,10 +29,10 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         </div>
 
         <div class="col-12 xl:col-5 mb-2 xl:mb-0 text-center xl:text-left">
-          <h2 class="text-color text-sm mb-3">
+          <h2 class="text-color paragraph-p5">
             Download Mergin Maps to your phone
           </h2>
-          <p class="opacity-60 text-xs">
+          <p class="opacity-60 paragraph-p6">
             Capture geo-info easily through your mobile/tablet with our mobile
             app.
           </p>

--- a/web-app/packages/lib/src/modules/dialog/components/ConfirmDialog.vue
+++ b/web-app/packages/lib/src/modules/dialog/components/ConfirmDialog.vue
@@ -5,16 +5,16 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 -->
 
 <template>
-  <div class="flex flex-column align-items-center pb-4 text-center gap-3">
+  <div class="flex flex-column align-items-center pb-4 text-center gap-4">
     <img
       v-if="severity === 'danger'"
       src="@/assets/trash.svg"
       alt="Cover for confirm dialog"
     />
     <img v-else src="@/assets/map-circle.svg" alt="Cover for confirm dialog" />
-    <span class="font-semibold text-color-forest text-lg">{{ text }}</span>
-    <span class="text-sm opacity-80">{{ description }}</span>
-    <span class="text-base font-semibold">{{ hint }}</span>
+    <span class="text-color-forest title-t1">{{ text }}</span>
+    <span class="paragraph-p6 opacity-80">{{ description }}</span>
+    <span class="title-t2">{{ hint }}</span>
     <span v-if="confirmField" class="flex p-float-label w-full p-input-filled">
       <PInputText
         autofocus

--- a/web-app/packages/lib/src/modules/layout/components/AppBreadcrumbs.vue
+++ b/web-app/packages/lib/src/modules/layout/components/AppBreadcrumbs.vue
@@ -33,7 +33,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
           <span :class="[item.icon, 'text-color']" />
           <span
             :class="[
-              'opacity-80 text-sm',
+              'opacity-80 paragraph-p5',
               item.active ? 'text-color-forest font-semibold' : 'text-color'
             ]"
             >{{ item.label }}</span

--- a/web-app/packages/lib/src/modules/layout/components/AppHeaderTemplate.vue
+++ b/web-app/packages/lib/src/modules/layout/components/AppHeaderTemplate.vue
@@ -48,8 +48,10 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             class="p-2 shadow-none"
           >
             <div class="mr-2 max-w-80 flex flex-column align-items-start">
-              <span :style="{ whiteSpace: 'nowrap' }">{{ userName }}</span>
-              <span v-if="renderNamespace" class="font-normal">
+              <span class="title-t4" :style="{ whiteSpace: 'nowrap' }">{{
+                userName
+              }}</span>
+              <span v-if="renderNamespace" class="paragraph-p6 opacity-80">
                 {{ currentWorkspace?.name || 'no workspace' }}
               </span>
             </div>
@@ -61,7 +63,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             ref="menu"
             :pt="{ root: { class: 'p-3' }, content: { class: 'p-0' } }"
           >
-            <div class="flex align-items-center mb-2">
+            <div class="flex align-items-center mb-3">
               <PAvatar
                 :label="$filters.getAvatar(loggedUser.email, loggedUser.name)"
                 size="large"
@@ -75,11 +77,11 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
                   }
                 }"
               />
-              <div class="flex flex-column gap-2 text-xs">
-                <p class="font-semibold overflow-wrap-anywhere">
+              <div class="flex flex-column">
+                <p class="title-t4 overflow-wrap-anywhere">
                   {{ getUserFullName }}
                 </p>
-                <p class="overflow-wrap-anywhere">
+                <p class="paragraph-p6 overflow-wrap-anywhere">
                   {{ loggedUser.email }}
                 </p>
               </div>

--- a/web-app/packages/lib/src/modules/layout/components/SideBarItem.vue
+++ b/web-app/packages/lib/src/modules/layout/components/SideBarItem.vue
@@ -18,15 +18,17 @@ function closeDrawer() {
 </script>
 
 <template>
-  <li class="p-2">
+  <li class="px-2">
     <router-link
       :class="[
-        'sidebar-item__link p-3 flex align-items-center transition-color transition-duration-200 no-underline border-round-lg text-sm',
+        'sidebar-item__link p-3 flex align-items-center transition-color transition-duration-200 no-underline border-round-lg paragraph-p5',
         item.active && 'sidebar-item__link--active'
       ]"
       :to="item.to"
       @click.native="closeDrawer"
-      ><div class="mr-2"><i :class="['text-xl', item.icon]"></i></div>
+      ><div class="mr-2 flex align-items-center">
+        <i :class="['paragraph-p3', item.icon]"></i>
+      </div>
       <span>{{ item.title }}</span></router-link
     >
   </li>

--- a/web-app/packages/lib/src/modules/layout/views/NotFoundView.vue
+++ b/web-app/packages/lib/src/modules/layout/views/NotFoundView.vue
@@ -15,7 +15,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
       class="not-found-view-container flex flex-column align-items-center text-center row-gap-4 p-4 lg:p-0"
     >
       <header>
-        <h1 class="text-6xl">Ooops, it seems the GPS has lost its way.</h1>
+        <h1 class="headline-h1">Ooops, it seems the GPS has lost its way.</h1>
       </header>
       <img src="@/assets/map-circle.svg" alt="Not found" />
       This page does not exist, check your url for mistakes, please.

--- a/web-app/packages/lib/src/modules/project/components/AccessRequestTableTemplate.vue
+++ b/web-app/packages/lib/src/modules/project/components/AccessRequestTableTemplate.vue
@@ -18,7 +18,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
     @page="onPage"
   >
     <template #header>
-      <h3 class="font-semibold text-xs text-color m-0">Access requests</h3>
+      <h3 class="font-semibold paragraph-p6 text-color m-0">Access requests</h3>
     </template>
     <template #list="slotProps">
       <template v-for="item in slotProps.items" :key="item.id">
@@ -26,7 +26,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         <div
           class="flex flex-column lg:flex-row align-items-center justify-content-between px-4 py-2 mt-0 border-bottom-1 border-gray-200 gap-2"
         >
-          <p class="w-12 lg:w-4 text-xs m-0">
+          <p class="w-12 lg:w-4 paragraph-p6 m-0">
             User
             <span class="font-semibold">{{ item.requested_by }}</span>
             requested an access to your project
@@ -35,7 +35,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
           <div
             class="flex w-12 lg:w-4 align-items-center flex-wrap lg:flex-nowrap row-gap-2"
           >
-            <p class="opacity-80 text-xs w-12">
+            <p class="opacity-80 paragraph-p6 w-12">
               <span v-tooltip.right="{ value: $filters.datetime(item.expire) }">
                 <template
                   v-if="$filters.remainingtime(item.expire) === 'expired'"
@@ -137,7 +137,7 @@ export default defineComponent({
           }
         },
         headerTitle: {
-          class: 'text-xs'
+          class: 'paragraph-p6'
         }
       }
     },

--- a/web-app/packages/lib/src/modules/project/components/CloneDialogTemplate.vue
+++ b/web-app/packages/lib/src/modules/project/components/CloneDialogTemplate.vue
@@ -5,7 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 -->
 
 <template>
-  <div class="flex flex-column py-4 gap-3">
+  <div class="flex flex-column py-4 gap-4">
     <span class="flex p-float-label w-ful p-input-filled">
       <PInputText
         autofocus

--- a/web-app/packages/lib/src/modules/project/components/DropArea.vue
+++ b/web-app/packages/lib/src/modules/project/components/DropArea.vue
@@ -39,10 +39,10 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         >
           <i class="ti ti-download" />
         </div>
-        <h4 class="text-lg font-semibold text-color-forest">
+        <h4 class="title-t1 font-semibold text-color-forest">
           Drag and drop files
         </h4>
-        <p class="text-sm opacity-80 m-0">
+        <p class="paragraph-p6 opacity-80 m-0">
           You can drop files from your computer to start uploading
         </p>
       </div>

--- a/web-app/packages/lib/src/modules/project/components/FileChangesetSummaryTable.vue
+++ b/web-app/packages/lib/src/modules/project/components/FileChangesetSummaryTable.vue
@@ -20,7 +20,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
     >
       <template #header>
         <div class="grid grid-nogutter">
-          <div v-for="col in columns" class="col-3 text-xs" :key="col.text">
+          <div v-for="col in columns" class="col-3 paragraph-p6" :key="col.text">
             <i
               v-if="col.icon"
               :class="['ti', `${col.icon}`]"
@@ -34,7 +34,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         <div
           v-for="item in slotProps.items"
           :key="item.id"
-          class="grid grid-nogutter px-4 py-2 mt-0 border-bottom-1 border-gray-200 text-sm hover:bg-gray-200"
+          class="grid grid-nogutter px-4 py-2 mt-0 border-bottom-1 border-gray-200 paragraph-p5 hover:bg-gray-200"
         >
           <div
             v-for="col in columns"

--- a/web-app/packages/lib/src/modules/project/components/FileDetailSidebar.vue
+++ b/web-app/packages/lib/src/modules/project/components/FileDetailSidebar.vue
@@ -28,25 +28,25 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 
         <dl class="grid grid-nogutter row-gap-4">
           <div class="col-12">
-            <dt class="text-xs opacity-80 mb-2">File</dt>
+            <dt class="paragraph-p6 opacity-80 mb-2">File</dt>
             <dl class="font-semibold">
-              <h3 class="text-2xl mt-0">
+              <h3 class="headline-h3 mt-0">
                 <FileIcon :file="{ ...file, name: fileName }" />{{ fileName }}
               </h3>
             </dl>
           </div>
           <PDivider class="m-0" />
           <div class="col-6">
-            <dt class="text-xs opacity-80 mb-2">Modified</dt>
-            <dl class="font-semibold text-sm">
+            <dt class="paragraph-p6 opacity-80 mb-2">Modified</dt>
+            <dl class="font-semibold paragraph-p5">
               <span v-tooltip="$filters.datetime(file.mtime)">{{
                 $filters.timediff(file.mtime)
               }}</span>
             </dl>
           </div>
           <div class="col-6 flex flex-column align-items-end">
-            <dt class="text-xs opacity-80 mb-2">Size</dt>
-            <dl class="font-semibold text-sm">
+            <dt class="paragraph-p6 opacity-80 mb-2">Size</dt>
+            <dl class="font-semibold paragraph-p5">
               {{ $filters.filesize(file.size) }}
               <span v-if="state === 'updated'"
                 >(new:
@@ -68,10 +68,10 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             imageClass="w-full"
           />
           <div
-            class="file-detail-code border-round-xl p-4 line-height-3 w-full"
+            class="file-detail-code border-round-xl p-4 paragraph-p4 w-full"
             v-else-if="mimetype.match('text')"
           >
-            <span class="opacity-80 text-sm">{{ content }}</span>
+            <span class="opacity-80 paragraph-p5">{{ content }}</span>
           </div>
         </output>
       </div>

--- a/web-app/packages/lib/src/modules/project/components/FileIcon.vue
+++ b/web-app/packages/lib/src/modules/project/components/FileIcon.vue
@@ -5,7 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 -->
 
 <template>
-  <div class="mr-2 text-lg">
+  <div class="mr-2 paragraph-p4">
     <template v-if="icon">
       <span>
         <img :src="icon" width="24" height="24" />

--- a/web-app/packages/lib/src/modules/project/components/ProjectAccessRequests.vue
+++ b/web-app/packages/lib/src/modules/project/components/ProjectAccessRequests.vue
@@ -18,7 +18,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
     @page="onPage"
   >
     <template #header>
-      <h3 class="font-semibold text-xs text-color m-0">Access requests</h3>
+      <h3 class="font-semibold paragraph-p6 text-color m-0">Access requests</h3>
     </template>
     <template #list="slotProps">
       <template v-for="item in slotProps.items" :key="item.id">
@@ -26,7 +26,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         <div
           class="flex flex-column lg:flex-row align-items-center justify-content-between px-4 py-2 mt-0 border-bottom-1 border-gray-200"
         >
-          <p class="w-12 lg:w-4 text-xs m-0">
+          <p class="w-12 lg:w-4 paragraph-p6 m-0">
             User
             <span class="font-semibold">{{ item.requested_by }}</span>
             requested an access to your project
@@ -35,7 +35,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
           <div
             class="flex w-12 lg:w-4 align-items-center flex-wrap lg:flex-nowrap row-gap-2"
           >
-            <p class="opacity-80 text-xs w-12">
+            <p class="opacity-80 paragraph-p6 w-12">
               <span v-tooltip.right="{ value: $filters.datetime(item.expire) }">
                 <template
                   v-if="$filters.remainingtime(item.expire) === 'expired'"

--- a/web-app/packages/lib/src/modules/project/components/ProjectMembersTable.vue
+++ b/web-app/packages/lib/src/modules/project/components/ProjectMembersTable.vue
@@ -22,7 +22,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             <!-- Visible on lg breakpoint > -->
             <div
               v-for="col in columns.filter((item) => !item.fixed)"
-              :class="['text-xs hidden lg:flex', `col-${col.cols ?? 4}`]"
+              :class="['paragraph-p6 hidden lg:flex', `col-${col.cols ?? 4}`]"
               :key="col.text"
             >
               {{ col.text }}
@@ -37,7 +37,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
           <div
             v-for="item in slotProps.items"
             :key="item.id"
-            class="flex align-items-center hover:bg-gray-50 border-bottom-1 border-gray-200 text-xs px-4 py-2 mt-0"
+            class="flex align-items-center hover:bg-gray-50 border-bottom-1 border-gray-200 paragraph-p6 px-4 py-2 mt-0"
           >
             <div class="w-11 grid grid-nogutter">
               <!-- Columns, we are using data view instead table, it is better handling of responsive state -->
@@ -102,7 +102,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
                 plain
                 text
                 @click.stop="removeMember(item)"
-                class="text-xl p-0"
+                class="paragraph-p3 p-0"
                 :style="{
                   visibility: projectStore.canRemoveProjectAccess(item)
                     ? 'visible'

--- a/web-app/packages/lib/src/modules/project/components/ProjectShareDialog.vue
+++ b/web-app/packages/lib/src/modules/project/components/ProjectShareDialog.vue
@@ -12,7 +12,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
     @submit="share"
   >
     <template #accountsInput
-      ><label class="text-xs" for="accounts">Share with</label
+      ><label class="paragraph-p6" for="accounts">Share with</label
       ><PAutoComplete
         @complete="search"
         v-model="data.selectedUsers"
@@ -45,10 +45,10 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             />
 
             <div class="flex flex-column">
-              <span class="tip-message-title text-sm font-semibold">
+              <span class="tip-message-title title-t3">
                 {{ option.value.username }}
               </span>
-              <span class="opacity-80 text-sm line-height-4">
+              <span class="opacity-80 paragraph-p5">
                 {{ option.value.email }}
               </span>
             </div>

--- a/web-app/packages/lib/src/modules/project/components/ProjectShareDialogTemplate.vue
+++ b/web-app/packages/lib/src/modules/project/components/ProjectShareDialogTemplate.vue
@@ -12,7 +12,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
       </div>
 
       <div class="flex flex-column row-gap-1 p-input-filled">
-        <label class="text-xs">Project permission</label>
+        <label class="paragraph-p6">Project permission</label>
         <app-dropdown :options="permissionStates" v-model="permission" />
       </div>
     </div>
@@ -27,7 +27,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         :href="docsUrl"
         target="_blank"
         class="text-color-forest w-12 lg:w-8 font-semibold flex align-items-center"
-        ><i class="ti ti-info-circle-filled mr-2 text-base" /><span
+        ><i class="ti ti-info-circle-filled mr-2 paragraph-p4" /><span
           class="underline"
           >Learn more about permission system</span
         ></a

--- a/web-app/packages/lib/src/modules/project/components/ProjectsTable.vue
+++ b/web-app/packages/lib/src/modules/project/components/ProjectsTable.vue
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
           class: 'bg-primary-reverse opacity-50'
         },
         bodyRow: {
-          class: 'text-xs hover:bg-gray-50 cursor-pointer'
+          class: 'paragraph-p6 hover:bg-gray-50 cursor-pointer'
         }
       }"
     >
@@ -39,7 +39,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
           :pt="ptColumn"
         >
           <template #body="slotProps">
-            <p class="font-semibold text-sm mb-2 m-0">
+            <p class="font-semibold paragraph-p5">
               <router-link
                 :to="{
                   name: 'project',
@@ -207,7 +207,7 @@ export default defineComponent({
           }
         },
         headerTitle: {
-          class: 'text-xs'
+          class: 'paragraph-p6'
         }
       }
     }

--- a/web-app/packages/lib/src/modules/project/components/ProjectsTableDataLoader.vue
+++ b/web-app/packages/lib/src/modules/project/components/ProjectsTableDataLoader.vue
@@ -17,7 +17,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
       <template #empty>
         <div class="flex flex-column align-items-center p-4 text-center">
           <img src="@/assets/map-circle.svg" alt="No projects" />
-          <p class="font-semibold m-0 p-4">
+          <p class="title-t2 m-0 p-4">
             <template v-if="projectsSearch"
               >We couldn't find any projects matching your search
               criteria.</template
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             <template v-else>You don't have any projects yet.</template>
           </p>
           <template v-if="canCreateProject">
-            <p class="text-sm opacity-80 pb-4">
+            <p class="paragraph-p6 opacity-80 pb-4">
               Let’s start by creating a first one!
             </p>
             <PButton @click="newProjectDialog">Create new project</PButton>

--- a/web-app/packages/lib/src/modules/project/components/UploadPanel.vue
+++ b/web-app/packages/lib/src/modules/project/components/UploadPanel.vue
@@ -27,7 +27,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         <app-circle :severity="circleSeverity[key]" class="mr-2"
           ><i :class="['ti', `${diffIcon[key]}`]"></i
         ></app-circle>
-        <span class="text-sm opacity-80 capitalize">{{ key }}</span>
+        <span class="paragraph-p5 opacity-80 capitalize">{{ key }}</span>
         <app-circle class="ml-auto">{{ upload.diff[key].length }}</app-circle>
       </div>
       <div class="py-4 w-full">

--- a/web-app/packages/lib/src/modules/project/components/VersionDetailSidebar.vue
+++ b/web-app/packages/lib/src/modules/project/components/VersionDetailSidebar.vue
@@ -22,35 +22,35 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
       ></template>
       <dl class="grid grid-nogutter row-gap-4">
         <div class="col-12">
-          <dt class="text-xs opacity-80 mb-2">Version</dt>
+          <dt class="paragraph-p6 opacity-80 mb-2">Version</dt>
           <dl>
-            <h3 class="text-2xl mt-0">
+            <h3 class="headline-h3 mt-0">
               {{ version.name }}
             </h3>
           </dl>
         </div>
         <PDivider class="m-0" />
         <div class="col-6">
-          <dt class="text-xs opacity-80 mb-2">Author</dt>
-          <dl class="font-semibold text-sm">
+          <dt class="paragraph-p6 opacity-80 mb-2">Author</dt>
+          <dl class="font-semibold paragraph-p5">
             {{ version.author }}
           </dl>
         </div>
         <div class="col-6 flex flex-column align-items-end">
-          <dt class="text-xs opacity-80 mb-2">Project size</dt>
-          <dl class="font-semibold text-sm">
+          <dt class="paragraph-p6 opacity-80 mb-2">Project size</dt>
+          <dl class="font-semibold paragraph-p5">
             {{ $filters.filesize(version.project_size) }}
           </dl>
         </div>
         <div class="col-12">
-          <dt class="text-xs opacity-80 mb-2">Created</dt>
-          <dl class="font-semibold text-sm">
+          <dt class="paragraph-p6 opacity-80 mb-2">Created</dt>
+          <dl class="font-semibold paragraph-p5">
             {{ $filters.datetime(version.created) }}
           </dl>
         </div>
         <div class="col-12">
-          <dt class="text-xs opacity-80 mb-2">User agent</dt>
-          <dl class="font-semibold text-sm">
+          <dt class="paragraph-p6 opacity-80 mb-2">User agent</dt>
+          <dl class="font-semibold paragraph-p5">
             {{ version.user_agent }}
           </dl>
         </div>
@@ -80,7 +80,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             <app-circle :severity="item.severity" class="mr-2">
               <i :class="['ti', `${item.icon}`]"></i>
             </app-circle>
-            <span class="text-sm opacity-80">{{ item.text }}</span>
+            <span class="paragraph-p5 opacity-80">{{ item.text }}</span>
             <app-circle class="ml-auto">
               {{ changes[item.key].length }}
             </app-circle></template
@@ -88,7 +88,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
           <div
             v-for="change in changes[item.key]"
             :key="change.path"
-            class="py-2 text-xs"
+            class="py-2 paragraph-p6"
           >
             <div class="flex align-items-center justify-content-between mb-2">
               <span class="w-10 font-semibold">{{ change.path }}</span>

--- a/web-app/packages/lib/src/modules/project/views/FileBrowserView.vue
+++ b/web-app/packages/lib/src/modules/project/views/FileBrowserView.vue
@@ -11,7 +11,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
       <app-section ground>
         <div class="flex align-items-center">
           <span class="p-input-icon-left flex-grow-1">
-            <i class="ti ti-search text-xl"></i>
+            <i class="ti ti-search paragraph-p3"></i>
             <PInputText
               placeholder="Search files"
               data-cy="search-files-field"
@@ -48,10 +48,10 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
               <img src="@/assets/Icon/24/QGIS.svg" width="24" height="24" />
             </div>
 
-            <h4 class="text-lg font-semibold text-color-forest">
+            <h4 class="title-t1 text-color-forest">
               Mergin Maps plugin for QGIS
             </h4>
-            <p class="text-sm opacity-80 m-0">
+            <p class="paragraph-p6 opacity-80 m-0">
               This is the easiest and recommended way.
               <a
                 target="_blank"
@@ -86,7 +86,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
               <!-- Visible on lg breakpoint > -->
               <div
                 v-for="col in columns"
-                :class="[`col-${col.cols ?? 3}`, 'text-xs hidden lg:flex']"
+                :class="[`col-${col.cols ?? 3}`, 'paragraph-p6 hidden lg:flex']"
                 :key="col.text"
               >
                 {{ col.text }}
@@ -99,7 +99,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             <div
               v-for="item in slotProps.items"
               :key="item.id"
-              class="grid grid-nogutter px-4 py-3 mt-0 border-bottom-1 border-gray-200 text-xs hover:bg-gray-50 cursor-pointer row-gap-2"
+              class="grid grid-nogutter px-4 py-3 mt-0 border-bottom-1 border-gray-200 paragraph-p6 hover:bg-gray-50 cursor-pointer row-gap-2"
               @click.prevent="rowClick(item.link)"
             >
               <!-- Columns, we are using data view instead table, it is better handling of respnsive state -->

--- a/web-app/packages/lib/src/modules/project/views/FileVersionDetailView.vue
+++ b/web-app/packages/lib/src/modules/project/views/FileVersionDetailView.vue
@@ -140,7 +140,7 @@ export default defineComponent({
           }
         },
         headerTitle: {
-          class: 'text-xs'
+          class: 'paragraph-p6'
         }
       }
     }

--- a/web-app/packages/lib/src/modules/project/views/ProjectCollaboratorsViewTemplate.vue
+++ b/web-app/packages/lib/src/modules/project/views/ProjectCollaboratorsViewTemplate.vue
@@ -23,7 +23,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
       <app-section ground>
         <div class="flex align-items-center gap-2">
           <span class="p-input-icon-left flex-grow-1">
-            <i class="ti ti-search text-xl"></i>
+            <i class="ti ti-search paragraph-p3"></i>
             <PInputText
               placeholder="Search members"
               data-cy="search-members-field"

--- a/web-app/packages/lib/src/modules/project/views/ProjectSettingsViewTemplate.vue
+++ b/web-app/packages/lib/src/modules/project/views/ProjectSettingsViewTemplate.vue
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
   <div>
     <app-container>
       <app-section>
-        <div class="flex flex-column row-gap-3 text-sm p-4">
+        <div class="flex flex-column row-gap-3 paragraph-p5 p-4">
           <div
             :class="[
               'flex flex-column align-items-start',
@@ -18,14 +18,14 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
           >
             <div class="flex-grow-1">
               <template v-if="project.access.public">
-                <p class="font-semibold my-2">This is public project</p>
-                <span class="text-xs opacity-80"
+                <p class="font-semibold">This is public project</p>
+                <span class="paragraph-p6 opacity-80"
                   >Hide this project from everyone.</span
                 >
               </template>
               <template v-else>
-                <p class="font-semibold my-2">This is private project</p>
-                <span class="text-xs opacity-80"
+                <p class="title-t3">This is private project</p>
+                <span class="paragraph-p6 opacity-80"
                   >Make this project visible to anyone.</span
                 >
               </template>
@@ -58,8 +58,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             v-if="project && project.permissions && project.permissions.delete"
           >
             <div class="flex-grow-1">
-              <p class="font-semibold my-2">Delete project</p>
-              <span class="text-xs opacity-80">All data will be lost</span>
+              <p class="title-t3">Delete project</p>
+              <span class="paragraph-p6 opacity-80">All data will be lost</span>
             </div>
             <div class="flex-shrink-0">
               <PButton

--- a/web-app/packages/lib/src/modules/project/views/ProjectVersionsViewTemplate.vue
+++ b/web-app/packages/lib/src/modules/project/views/ProjectVersionsViewTemplate.vue
@@ -34,7 +34,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             <!-- Visible on lg breakpoint > -->
             <div
               v-for="col in columns.filter((item) => !item.fixed)"
-              :class="['text-xs hidden lg:flex', `col-${col.cols ?? 2}`]"
+              :class="['paragraph-p6 hidden lg:flex', `col-${col.cols ?? 2}`]"
               :key="col.text"
             >
               {{ col.text }}
@@ -49,7 +49,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
           <div
             v-for="item in slotProps.items"
             :key="item.id"
-            class="flex align-items-center hover:bg-gray-50 cursor-pointer border-bottom-1 border-gray-200 text-xs px-3 py-2 mt-0"
+            class="flex align-items-center hover:bg-gray-50 cursor-pointer border-bottom-1 border-gray-200 paragraph-p6 px-3 py-2 mt-0"
             :style="[rowStyle(item)]"
             @click.prevent="!item.disabled && rowClick(item.name)"
           >
@@ -73,7 +73,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
                   </span>
                 </template>
                 <template v-else-if="col.value === 'created'">
-                  <p class="text-xs opacity-80 font-semibold lg:hidden">
+                  <p class="paragraph-p6 opacity-80 font-semibold lg:hidden">
                     {{ col.text }}
                   </p>
                   <span
@@ -86,7 +86,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
                   </span>
                 </template>
                 <template v-else-if="col.value === 'changes.added'">
-                  <p class="text-xs opacity-80 font-semibold lg:hidden">
+                  <p class="paragraph-p6 opacity-80 font-semibold lg:hidden">
                     {{ col.text }}
                   </p>
                   <span :class="col.textClass">{{
@@ -94,7 +94,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
                   }}</span>
                 </template>
                 <template v-else-if="col.value === 'changes.updated'">
-                  <p class="text-xs opacity-80 font-semibold lg:hidden">
+                  <p class="paragraph-p6 opacity-80 font-semibold lg:hidden">
                     {{ col.text }}
                   </p>
                   <span :class="col.textClass">
@@ -102,7 +102,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
                   </span>
                 </template>
                 <template v-else-if="col.value === 'changes.removed'">
-                  <p class="text-xs opacity-80 font-semibold lg:hidden">
+                  <p class="paragraph-p6 opacity-80 font-semibold lg:hidden">
                     {{ col.text }}
                   </p>
                   <span :class="col.textClass">
@@ -110,7 +110,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
                   </span>
                 </template>
                 <template v-else-if="col.value === 'project_size'">
-                  <p class="text-xs opacity-80 font-semibold lg:hidden">
+                  <p class="paragraph-p6 opacity-80 font-semibold lg:hidden">
                     {{ col.text }}
                   </p>
                   <span :class="col.textClass">{{
@@ -118,7 +118,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
                   }}</span>
                 </template>
                 <template v-else>
-                  <p class="text-xs opacity-80 font-semibold lg:hidden">
+                  <p class="paragraph-p6 opacity-80 font-semibold lg:hidden">
                     {{ col.text }}
                   </p>
                   <span :class="col.textClass">{{ item[col.value] }}</span>
@@ -134,7 +134,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
                 text
                 :disabled="item.disabled"
                 :style="[rowStyle(item)]"
-                class="text-xl"
+                class="paragraph-p3"
                 data-cy="project-versions-download-btn"
                 @click.stop="
                   downloadArchive({

--- a/web-app/packages/lib/src/modules/project/views/ProjectViewTemplate.vue
+++ b/web-app/packages/lib/src/modules/project/views/ProjectViewTemplate.vue
@@ -80,7 +80,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         <div class="flex flex-column align-items-center p-4 text-center gap-4">
           <img src="@/assets/map-circle.svg" alt="No project" />
           <p class="font-semibold">This is a private project</p>
-          <p class="text-sm opacity-80 mt-2 mb-4">
+          <p class="paragraph-p5 opacity-80 mt-2 mb-4">
             You don't have permissions to access this project.
           </p>
           <PButton id="request-access-btn" @click="createAccessRequest"
@@ -92,7 +92,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         <div class="flex flex-column align-items-center p-4 text-center gap-4">
           <img src="@/assets/map-circle.svg" alt="No project" />
           <p class="font-semibold">Project not found</p>
-          <p class="text-sm opacity-80 mt-2 mb-4">
+          <p class="paragraph-p5 opacity-80 mt-2 mb-4">
             Please check if address is written correctly
           </p>
         </div>
@@ -103,7 +103,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
           <p class="font-semibold">
             You don't have permission to access this project
           </p>
-          <p class="text-sm opacity-80 mt-2 mb-4">
+          <p class="paragraph-p5 opacity-80 mt-2 mb-4">
             You already requested access
           </p>
         </div>

--- a/web-app/packages/lib/src/modules/project/views/ProjectsListViewTemplate.vue
+++ b/web-app/packages/lib/src/modules/project/views/ProjectsListViewTemplate.vue
@@ -10,7 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
       <template v-if="!namespace">
         <app-section ground class="mb-3">
           <template #header>
-            <h1 class="text-3xl">
+            <h1 class="headline-h3">
               {{ header }}
               <span class="text-color-medium-green">({{ projectsCount }})</span>
             </h1>
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
           </template>
           <div class="flex align-items-center justify-content-between mt-3">
             <span class="p-input-icon-left flex-grow-1">
-              <i class="ti ti-search text-xl"></i>
+              <i class="ti ti-search paragraph-p3"></i>
               <PInputText
                 placeholder="Search projects by name"
                 v-model="projectsStore.projectsSearch"

--- a/web-app/packages/lib/src/modules/user/components/ChangePasswordForm.vue
+++ b/web-app/packages/lib/src/modules/user/components/ChangePasswordForm.vue
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 <template>
   <div class="flex flex-column pb-4 row-gap-1">
     <span class="p-input-filled">
-      <label class="text-xs" for="oldPassowrd">Old password</label>
+      <label class="paragraph-p6" for="oldPassowrd">Old password</label>
       <PPassword
         id="oldPassowrd"
         v-model="oldPassword"
@@ -18,7 +18,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         aria-describedby="old-password-error"
         placeholder="Please enter your password"
       />
-      <span class="p-error text-xs" id="old-password-error">{{
+      <span class="p-error paragraph-p6" id="old-password-error">{{
         errors.old_password?.[0] || '&nbsp;'
       }}</span>
     </span>
@@ -38,7 +38,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         :feedback="false"
         placeholder="Please enter your new password"
       />
-      <span class="p-error text-xs" id="password-error">{{
+      <span class="p-error paragraph-p6" id="password-error">{{
         errors.password?.[0] || '&nbsp;'
       }}</span>
     </span>
@@ -59,7 +59,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         placeholder="Please enter your new password"
       />
 
-      <span class="p-error text-xs" id="confirm-password-error">{{
+      <span class="p-error paragraph-p6" id="confirm-password-error">{{
         errors.confirm?.[0] || '&nbsp;'
       }}</span>
     </span>

--- a/web-app/packages/lib/src/modules/user/components/EditProfileForm.vue
+++ b/web-app/packages/lib/src/modules/user/components/EditProfileForm.vue
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 <template>
   <form @submit.prevent="submit" class="flex flex-column pb-4 row-gap-1">
     <span class="p-input-filled">
-      <label class="text-xs" for="first-name">First name</label>
+      <label class="paragraph-p6" for="first-name">First name</label>
       <PInputText
         id="first-name"
         v-model="editedProfile.first_name"
@@ -17,13 +17,13 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         :feedback="false"
         aria-describedby="first-name-error"
       />
-      <span class="p-error text-xs" id="first-name-error">{{
+      <span class="p-error paragraph-p6" id="first-name-error">{{
         errors.first_name?.[0] || '&nbsp;'
       }}</span>
     </span>
 
     <span class="p-input-filled">
-      <label class="text-xs" for="last-name">Last name</label>
+      <label class="paragraph-p6" for="last-name">Last name</label>
       <PInputText
         id="last-name"
         v-model="editedProfile.last_name"
@@ -33,13 +33,13 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         :feedback="false"
         aria-describedby="last-name-error"
       />
-      <span class="p-error text-xs" id="last-name-error">{{
+      <span class="p-error paragraph-p6" id="last-name-error">{{
         errors.last_name?.[0] || '&nbsp;'
       }}</span>
     </span>
 
     <span class="p-input-filled">
-      <label class="text-xs" for="email">Email</label>
+      <label class="paragraph-p6" for="email">Email</label>
       <PInputText
         id="email"
         v-model="editedProfile.email"
@@ -49,7 +49,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         :feedback="false"
         aria-describedby="email-error"
       />
-      <span class="p-error text-xs" id="email-error">{{
+      <span class="p-error paragraph-p6" id="email-error">{{
         errors.email?.[0] || '&nbsp;'
       }}</span>
     </span>

--- a/web-app/packages/lib/src/modules/user/views/ChangePasswordView.vue
+++ b/web-app/packages/lib/src/modules/user/views/ChangePasswordView.vue
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 
 <template>
   <app-onboarding-page>
-    <template #header><h1 class="text-6xl">Change password</h1></template>
+    <template #header><h1 class="headline-h1">Change password</h1></template>
 
     <form
       v-if="!success"
@@ -32,7 +32,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             }
           }"
         />
-        <span class="p-error text-xs" id="password-error">{{
+        <span class="p-error paragraph-p6" id="password-error">{{
           errors.password?.[0] || '&nbsp;'
         }}</span>
       </span>
@@ -58,7 +58,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
           }"
         />
 
-        <span class="p-error text-xs" id="confirm-password-error">{{
+        <span class="p-error paragraph-p6" id="confirm-password-error">{{
           errors.confirm?.[0] || '&nbsp;'
         }}</span>
       </span>
@@ -76,7 +76,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
       <span
         >Your password was changed. You can now
         <router-link
-          class="text-sm text-color-forest font-semibold align-self-center"
+          class="text-color-forest title-t3 align-self-center"
           :to="{ name: 'login' }"
           >Sign in</router-link
         ></span

--- a/web-app/packages/lib/src/modules/user/views/LoginViewTemplate.vue
+++ b/web-app/packages/lib/src/modules/user/views/LoginViewTemplate.vue
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 <template>
   <app-onboarding-page>
     <template #header>
-      <h1 class="text-6xl">
+      <h1 class="headline-h1">
         <template v-if="forgotPassword">Reset password</template
         ><template v-else>Sign in</template>
       </h1>
@@ -23,7 +23,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
       class="flex flex-column row-gap-1"
     >
       <div>
-        <label class="text-xs" for="login">Email</label>
+        <label class="paragraph-p6" for="login">Email</label>
         <PInputText
           placeholder="Type your email"
           name="email"
@@ -32,13 +32,13 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
           v-model="email"
           :class="['w-full my-1', errors.email ? 'p-invalid' : '']"
         />
-        <span class="p-error text-xs" id="login-error">{{
+        <span class="p-error paragraph-p6" id="login-error">{{
           errors.email?.[0] || '&nbsp;'
         }}</span>
       </div>
 
       <router-link
-        class="text-sm text-color-forest font-semibold align-self-center"
+        class="text-color-forest align-self-center font-semibold"
         :to="{ name: 'login' }"
         >Back to login</router-link
       >
@@ -53,7 +53,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
     </form>
     <form v-else @submit.prevent="loginUser" class="flex flex-column row-gap-1">
       <div>
-        <label class="text-xs" for="login">Username or email</label>
+        <label class="paragraph-p6" for="login">Username or email</label>
         <PInputText
           id="login"
           name="login"
@@ -65,13 +65,13 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
           :inputProps="{ autocomplete: 'on' }"
           autofocus
         />
-        <span class="p-error text-xs" id="login-error">{{
+        <span class="p-error paragraph-p6" id="login-error">{{
           errors.login?.[0] || '&nbsp;'
         }}</span>
       </div>
 
       <div>
-        <label class="text-xs" for="password">Password</label>
+        <label class="paragraph-p6" for="password">Password</label>
         <PPassword
           id="password"
           name="password"
@@ -91,13 +91,13 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             }
           }"
         />
-        <span class="p-error text-xs" id="password-error">{{
+        <span class="p-error paragraph-p6" id="password-error">{{
           errors.password?.[0] || '&nbsp;'
         }}</span>
       </div>
 
       <router-link
-        class="text-sm text-color-forest font-semibold align-self-center"
+        class="text-color-forest title-t3 align-self-center"
         :to="{ name: 'login', params: { reset: 'reset' } }"
         >Forgot password?</router-link
       >
@@ -108,6 +108,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         data-cy="login-form-btn-login"
         id="login-btn"
         class="mt-6 w-full"
+        size="large"
         label="Sign in"
       />
     </form>

--- a/web-app/packages/lib/src/modules/user/views/ProfileViewTemplate.vue
+++ b/web-app/packages/lib/src/modules/user/views/ProfileViewTemplate.vue
@@ -11,7 +11,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         class="flex flex-column lg:flex-row lg:align-items-center row-gap-3"
       >
         <!-- Title with buttons -->
-        <h1 class="text-2xl text-color font-semibold">Account details</h1>
+        <h1 class="headline-h3 text-color font-semibold">Account details</h1>
         <div class="flex flex-grow-1 align-items-center lg:justify-content-end">
           <PButton
             @click="editProfileDialog"
@@ -48,9 +48,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             @click="resendConfirmationEmail"
             severity="secondary"
             data-cy="profile-send-email-btn"
-            >Send confirmation email
-          </PButton></template
-        >
+            label="Send confirmation email"
+        /></template>
       </app-section-banner>
     </app-container>
     <app-container>
@@ -69,10 +68,13 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
               }
             }"
           />
-          <h3 class="text-4xl" data-cy="profile-username">
+          <h3 class="headline-h2" data-cy="profile-username">
             {{ loggedUser?.username }}
           </h3>
-          <p class="m-0 text-xs overflow-wrap-anywhere" data-cy="profile-email">
+          <p
+            class="m-0 paragraph-p6 overflow-wrap-anywhere"
+            data-cy="profile-email"
+          >
             <i
               v-if="!loggedUser?.verified_email"
               v-tooltip.top="{
@@ -84,17 +86,17 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             ></i
             >&nbsp;{{ loggedUser?.email }}
           </p>
-          <dl class="profile-view-detail-list grid grid-nogutter text-sm">
+          <dl class="profile-view-detail-list grid grid-nogutter paragraph-p5">
             <div
               class="col-6 flex flex-column align-items-start text-left flex-wrap"
             >
-              <dt class="text-xs opacity-80 mb-2">Full name</dt>
+              <dt class="paragraph-p6 opacity-80 mb-2">Full name</dt>
               <dl class="font-semibold" data-cy="profile-name">
                 {{ loggedUser?.name || '-' }}
               </dl>
             </div>
             <div class="col-6 flex flex-column align-items-end">
-              <dt class="text-xs opacity-80 mb-2">Registered</dt>
+              <dt class="paragraph-p6 opacity-80 mb-2">Registered</dt>
               <dl class="font-semibold" data-cy="profile-registered">
                 {{ $filters.date(loggedUser?.registration_date) }}
               </dl>
@@ -106,7 +108,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
     <app-container>
       <app-section>
         <template #title>Advanced</template>
-        <div class="flex flex-column row-gap-3 text-sm px-4 pb-4">
+        <div class="flex flex-column row-gap-3 paragraph-p5 px-4 pb-4">
           <div
             :class="[
               'flex flex-column align-items-start',
@@ -115,8 +117,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             ]"
           >
             <div class="flex-grow-1">
-              <p class="font-semibold my-2">Receive notifications</p>
-              <span class="text-xs opacity-80"
+              <p class="title-t3">Receive notifications</p>
+              <span class="paragraph-p6 opacity-80"
                 >We will send you information about workspace activity</span
               >
             </div>
@@ -138,8 +140,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             ]"
           >
             <div class="flex-grow-1">
-              <p class="font-semibold my-2">Close account</p>
-              <span class="text-xs opacity-80"
+              <p class="title-t3">Close account</p>
+              <span class="paragraph-p6 opacity-80"
                 >Your account will be closed. In case you are an owner of a
                 workspace, you might need to transfer the ownership first or
                 close the workspace.</span

--- a/web-app/packages/lib/src/modules/user/views/VerifyEmailView.vue
+++ b/web-app/packages/lib/src/modules/user/views/VerifyEmailView.vue
@@ -7,12 +7,12 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 <template>
   <app-onboarding-page>
     <template #header>
-      <h1 class="text-6xl">Email confirmation</h1>
+      <h1 class="headline-h1">Email confirmation</h1>
     </template>
     <div class="flex flex-column gap-4 align-items-center">
       <template v-if="verified"
         ><img src="@/assets/neutral.svg" alt="MerginMaps neutral" /><span
-          class="opacity-80 text-sm"
+          class="opacity-80 paragraph-p5"
           >Your email address has been verified.</span
         ></template
       >


### PR DESCRIPTION
**details**

text-{size} replacement with paragraph-, title-, headline classes . Update of font size for buttons on Login/Register ... pages where font-size will be 14px now.

Cleanup:
- line-height classes
- m-0 class from h1...h6 and paragraphs (we have this style in reset)
Fix:
- font size in tags