### PR TITLE
Text in my access requests

### DIFF
--- a/web-app/packages/lib/src/common/components/AppSectionBanner.vue
+++ b/web-app/packages/lib/src/common/components/AppSectionBanner.vue
@@ -56,7 +56,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
       </template>
       <!-- Header without additional styles -->
       <template v-else #header><slot name="header"></slot></template>
-      <div><slot></slot></div>
+      <div class="paragraph-p6 opacity-80"><slot></slot></div>
 
       <template v-if="$slots.footer" #footer>
         <slot name="footer"></slot>

--- a/web-app/packages/lib/src/modules/instance/components/InstanceMaintenanceMessage.vue
+++ b/web-app/packages/lib/src/modules/instance/components/InstanceMaintenanceMessage.vue
@@ -5,7 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 -->
 
 <template>
-  <app-container>
+  <app-container class="relative z-5">
     <PMessage severity="warn" :closable="false" class="m-0">
       <template #messageicon="slotProps">
         <i :class="[slotProps.class, 'ti ti-alert-triangle-filled']" />

--- a/web-app/packages/lib/src/modules/project/components/AccessRequestTableTemplate.vue
+++ b/web-app/packages/lib/src/modules/project/components/AccessRequestTableTemplate.vue
@@ -26,7 +26,16 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         <div
           class="flex flex-column lg:flex-row align-items-center justify-content-between px-4 py-2 mt-0 border-bottom-1 border-gray-200 gap-2"
         >
-          <p class="w-12 lg:w-4 paragraph-p6 m-0">
+          <p
+            v-if="loggedUser.username === item.requested_by"
+            class="w-12 lg:w-4 paragraph-p6"
+          >
+            You requested an access to project
+            <span class="font-semibold">{{ item.project_name }}</span> in
+            workspace <span class="font-semibold">{{ item.namespace }}</span
+            >.
+          </p>
+          <p v-else class="w-12 lg:w-4 paragraph-p6">
             User
             <span class="font-semibold">{{ item.requested_by }}</span>
             requested an access to your project
@@ -95,6 +104,7 @@ import {
   ProjectPermissionName,
   getProjectPermissionsValues
 } from '@/common/permission_utils'
+import { useUserStore } from '@/main'
 import { useNotificationStore } from '@/modules/notification/store'
 import { useProjectStore } from '@/modules/project/store'
 import {
@@ -126,20 +136,9 @@ export default defineComponent({
   },
   computed: {
     ...mapState(useProjectStore, ['accessRequests', 'accessRequestsCount']),
+    ...mapState(useUserStore, ['loggedUser']),
     showAccept() {
       return this.namespace != null
-    },
-    ptColumn() {
-      return {
-        headerCell: {
-          style: {
-            backgroundColor: '#F8F9FA'
-          }
-        },
-        headerTitle: {
-          class: 'paragraph-p6'
-        }
-      }
     },
     permissions(): Record<number, ProjectPermissionName> {
       return {


### PR DESCRIPTION
**Details**

ticket: https://github.com/MerginMaps/MerginMaps-Cloud-TEST/issues/230

In the access requests table, if the current user is the one who initiated the requests (such as in the ProfileView view), display appropriate text for them in the corresponding row.

![image](https://github.com/MerginMaps/server/assets/12643115/dd01c69e-aef2-43c5-907a-f1ab512ad36d)

:hammer: Minor fixes:

- update spacing in section banner body