### PR TITLE
Store last seen workspaces in local storage

### DIFF
--- a/web-app/packages/app/src/App.vue
+++ b/web-app/packages/app/src/App.vue
@@ -122,12 +122,12 @@ export default defineComponent({
     })
     const toast = useToast()
     const notificationStore = useNotificationStore()
+    const layoutStore = useLayoutStore()
 
     notificationStore.init(toast)
+    layoutStore.init()
   },
   async created() {
-    this.init()
-
     await this.fetchConfig()
     if (this.loggedUser) {
       // here is loaded current workspace on startup (and reloaded in watcher when user has changed)
@@ -136,7 +136,7 @@ export default defineComponent({
 
     const pingDataResponse = await this.fetchPing()
     const getIsMaintenance = () => {
-      return pingDataResponse && pingDataResponse.maintenance
+      return pingDataResponse?.data?.maintenance
     }
 
     const resetUser = () => {
@@ -157,8 +157,7 @@ export default defineComponent({
     ...mapActions(useNotificationStore, {
       notificationError: 'error'
     }),
-    ...mapActions(useUserStore, ['checkCurrentWorkspace', 'updateLoggedUser']),
-    ...mapActions(useLayoutStore, ['init'])
+    ...mapActions(useUserStore, ['checkCurrentWorkspace', 'updateLoggedUser'])
   }
 })
 </script>

--- a/web-app/packages/app/src/modules/project/views/ProjectCollaboratorsView.vue
+++ b/web-app/packages/app/src/modules/project/views/ProjectCollaboratorsView.vue
@@ -21,9 +21,9 @@ import {
   useProjectStore,
   useUserStore,
   useInstanceStore,
-  useNotificationStore
+  useNotificationStore,
+  errorUtils
 } from '@mergin/lib'
-import { getErrorMessage } from '@mergin/lib/types/common/error_utils';
 import { computed } from 'vue'
 
 const projectStore = useProjectStore()
@@ -46,7 +46,10 @@ function openShareDialog() {
       listeners: {
         onShareError: (err) => {
           notificationStore.error({
-            text: getErrorMessage(err, 'Failed to save project settings')
+            text: errorUtils.getErrorMessage(
+              err,
+              'Failed to save project settings'
+            )
           })
         }
       }

--- a/web-app/packages/lib/src/common/local_storage.ts
+++ b/web-app/packages/lib/src/common/local_storage.ts
@@ -1,0 +1,40 @@
+export type StorageValue<T = object> = T extends object
+  ? T
+  : { [key: string]: T }
+
+export type StorageProxy<T> = {
+  value?: StorageValue<T>
+}
+
+export function createStorage<T>(
+  storageKey: string,
+  defaultValue: StorageValue<T>
+) {
+  return new Proxy<StorageProxy<T>>(
+    { value: defaultValue },
+    {
+      get(target, propKey): StorageValue<T> {
+        if (propKey !== 'value') {
+          return undefined
+        }
+
+        const item = localStorage.getItem(storageKey)
+        const result = item
+          ? (JSON.parse(item)[propKey] as StorageValue<T>)
+          : defaultValue
+
+        target[propKey] = result
+        return result
+      },
+      set(target, propKey: string, value: StorageValue<T>) {
+        target.value = value
+        localStorage.setItem(storageKey, JSON.stringify(target))
+        return true
+      },
+      deleteProperty() {
+        localStorage.removeItem(storageKey)
+        return true
+      }
+    }
+  )
+}

--- a/web-app/packages/lib/src/common/local_storage.ts
+++ b/web-app/packages/lib/src/common/local_storage.ts
@@ -1,3 +1,7 @@
+// Copyright (C) Lutra Consulting Limited
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
+
 export type StorageValue<T = object> = T extends object
   ? T
   : { [key: string]: T }

--- a/web-app/packages/lib/src/modules/instance/store.ts
+++ b/web-app/packages/lib/src/modules/instance/store.ts
@@ -51,9 +51,6 @@ export const useInstanceStore = defineStore('instanceModule', {
     setPingData(payload: PingResponse) {
       this.pingData = payload
     },
-    setInitialized() {
-      this.initialized = true
-    },
     async initApp() {
       const notificationStore = useNotificationStore()
       try {
@@ -64,7 +61,6 @@ export const useInstanceStore = defineStore('instanceModule', {
           // fetch user profile if user is logged in
           await userStore.fetchUserProfile()
         }
-        this.setInitialized()
         return response
       } catch {
         notificationStore.error({ text: 'Failed to init application.' })

--- a/web-app/packages/lib/src/modules/layout/components/AppHeaderTemplate.vue
+++ b/web-app/packages/lib/src/modules/layout/components/AppHeaderTemplate.vue
@@ -51,7 +51,10 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
               <span class="title-t4" :style="{ whiteSpace: 'nowrap' }">{{
                 userName
               }}</span>
-              <span v-if="renderNamespace" class="paragraph-p6 opacity-80">
+              <span
+                v-if="renderNamespace"
+                class="paragraph-p6 opacity-80 font-normal"
+              >
                 {{ currentWorkspace?.name || 'no workspace' }}
               </span>
             </div>

--- a/web-app/packages/lib/src/modules/project/components/AccessRequestTableTemplate.vue
+++ b/web-app/packages/lib/src/modules/project/components/AccessRequestTableTemplate.vue
@@ -28,14 +28,14 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         >
           <p
             v-if="loggedUser.username === item.requested_by"
-            class="w-12 lg:w-4 paragraph-p6"
+            class="w-12 lg:w-6 paragraph-p6"
           >
             You requested an access to project
             <span class="font-semibold">{{ item.project_name }}</span> in
             workspace <span class="font-semibold">{{ item.namespace }}</span
             >.
           </p>
-          <p v-else class="w-12 lg:w-4 paragraph-p6">
+          <p v-else class="w-12 lg:w-6 paragraph-p6">
             User
             <span class="font-semibold">{{ item.requested_by }}</span>
             requested an access to your project

--- a/web-app/packages/lib/src/modules/user/store.ts
+++ b/web-app/packages/lib/src/modules/user/store.ts
@@ -386,7 +386,7 @@ export const useUserStore = defineStore('userModule', {
         return
       }
       this.setWorkspaceId({ id: payload.workspaceId })
-      if (!payload.skipSavingInCookies) {
+      if (!payload.skipStorage) {
         // Append current workspace with last seen parameter
         this.lastWorkspaces.value = [
           ...this.lastWorkspaces.value.filter(
@@ -426,18 +426,18 @@ export const useUserStore = defineStore('userModule', {
     /**
      * Checks the current workspace that the user is in.
      *
-     * Tries to get the current workspace ID from the cookies.
+     * Tries to get the current workspace ID from the local storage array of last seen ws.
      * If not found, tries to use the preferred workspace ID from the user profile.
      * If still not found, defaults to using the first workspace in the user's list of workspaces.
      *
-     * Sets the current workspace in the store, and saves to cookies if needed.
+     * Sets the current workspace in the store, and saves to local storage if needed.
      */
     async checkCurrentWorkspace() {
       try {
         await this.getWorkspaces()
         let foundWorkspace = this.getLastWorkspaceFromStorage()
         if (this.workspaces.length > 0) {
-          let skipSavingInCookies = true
+          let skipStorage = true
           if (!foundWorkspace) {
             // try to use preferred_workspace from user profile response
             const preferredWorkspaceId = this.loggedUser?.preferred_workspace
@@ -445,8 +445,8 @@ export const useUserStore = defineStore('userModule', {
               id: preferredWorkspaceId
             })
             if (foundWorkspace?.id) {
-              // do not skip saving in cookies when using preferredWorkspace
-              skipSavingInCookies = false
+              // do not skip saving in local storage when using preferredWorkspace
+              skipStorage = false
             }
           }
           // use id from found workspace, if not found fallback to first workspace from user workspaces
@@ -455,9 +455,9 @@ export const useUserStore = defineStore('userModule', {
           await this.setWorkspace({
             workspaceId: currentWorkspaceIdToSet,
             // do not save workspaceId to storage as it could be:
-            // * already there, if was loaded from cookies
+            // * already there, if was loaded from local storage
             // * used the first user workspace as fallback, then it is not a user choice
-            skipSavingInCookies
+            skipStorage
           })
         } else {
           await this.cleanupLastSeenWorkspaces()

--- a/web-app/packages/lib/src/modules/user/store.ts
+++ b/web-app/packages/lib/src/modules/user/store.ts
@@ -2,13 +2,12 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 
-import isObject from 'lodash/isObject'
 import { defineStore, getActivePinia } from 'pinia'
-import Cookies from 'universal-cookie'
 import { isNavigationFailure } from 'vue-router'
 
 import { getErrorMessage } from '@/common/error_utils'
 import { waitCursor } from '@/common/html_utils'
+import { createStorage, StorageProxy } from '@/common/local_storage'
 import { isAtLeastRole, UserRole } from '@/common/permission_utils'
 import { useDialogStore } from '@/modules/dialog/store'
 import { useFormStore } from '@/modules/form/store'
@@ -26,7 +25,8 @@ import {
   WorkspaceResponse,
   SetWorkspaceIdPayload,
   UserSearchParams,
-  EditUserProfileParams
+  EditUserProfileParams,
+  LastSeenWorkspace
 } from '@/modules/user/types'
 import { UserApi } from '@/modules/user/userApi'
 
@@ -34,16 +34,20 @@ export interface UserState {
   loggedUser?: UserDetailResponse
   workspaces: WorkspaceResponse[]
   workspaceId: number
+  lastWorkspaces: StorageProxy<LastSeenWorkspace[]>
 }
 
-const cookies = new Cookies()
-const COOKIES_CURRENT_WORKSPACE = 'currentWorkspace'
+const lastWorkspacesStorage = createStorage<LastSeenWorkspace[]>(
+  'mm-last-workspaces',
+  []
+)
 
 export const useUserStore = defineStore('userModule', {
   state: (): UserState => ({
     loggedUser: null,
     workspaces: [],
-    workspaceId: undefined
+    workspaceId: undefined,
+    lastWorkspaces: lastWorkspacesStorage
   }),
 
   getters: {
@@ -62,11 +66,8 @@ export const useUserStore = defineStore('userModule', {
       return isAtLeastRole(this.getPreferredWorkspace?.role, UserRole.admin)
     },
     getPreferredWorkspace: (state) => {
-      return (
-        state.loggedUser?.workspaces &&
-        state.loggedUser?.workspaces.find(
-          (workspace) => workspace.id === state.loggedUser.preferred_workspace
-        )
+      return state.loggedUser?.workspaces?.find(
+        (workspace) => workspace.id === state.loggedUser.preferred_workspace
       )
     },
     getUserFullName: (state) => {
@@ -98,7 +99,7 @@ export const useUserStore = defineStore('userModule', {
       )
     },
     getWorkspaceById(state) {
-      return (payload: WorkspaceIdPayload) => {
+      return (payload: WorkspaceIdPayload): WorkspaceResponse | undefined => {
         return state.workspaces.find((workspace) => workspace.id === payload.id)
       }
     },
@@ -347,7 +348,7 @@ export const useUserStore = defineStore('userModule', {
       return newWorkspace
     },
 
-    async getWorkspaces() {
+    async getWorkspaces(): Promise<void> {
       const notificationStore = useNotificationStore()
 
       let workspacesResponse
@@ -380,153 +381,72 @@ export const useUserStore = defineStore('userModule', {
       }
     },
 
-    async getPreferredWorkspaceId() {
-      let preferredWorkspaceId
-      try {
-        const userProfileResponse = await this.fetchUserProfile()
-        preferredWorkspaceId = userProfileResponse.preferred_workspace
-      } catch (err) {
-        console.warn('Failed to get preferred workspace id', err)
-      }
-      return preferredWorkspaceId
-    },
-
     async setWorkspace(payload: SetWorkspaceIdPayload) {
       if (this.workspaceId === payload.workspaceId) {
         return
       }
-      // 'setWorkspaceId' and 'projectModule/setCurrentNamespace' has to be called together synchronously.
-      // In case when there is some async call between their calls, the watchers can be updated incorrectly
       this.setWorkspaceId({ id: payload.workspaceId })
       if (!payload.skipSavingInCookies) {
-        return await this.setUserWorkspaceToCookies({
-          id: payload.workspaceId
-        })
-      }
-    },
-
-    async getAllUserWorkspacesFromCookies() {
-      let value: Record<string, string>
-      try {
-        const cookieValue = cookies.get(COOKIES_CURRENT_WORKSPACE, {
-          doNotParse: true
-        })
-        if (cookieValue) {
-          const parsedValue = JSON.parse(cookieValue)
-          if (isObject(parsedValue)) {
-            value = parsedValue
-          } else {
-            console.warn(
-              `Stored cookies (${COOKIES_CURRENT_WORKSPACE}) value is not an object, removing it.`
-            )
-            // stored cookies value has deprecated format
-            cookies.remove(COOKIES_CURRENT_WORKSPACE)
+        // Append current workspace with last seen parameter
+        this.lastWorkspaces.value = [
+          ...this.lastWorkspaces.value.filter(
+            (item) =>
+              item.id !== payload.workspaceId ||
+              item.userId !== this.loggedUser.id
+          ),
+          {
+            lastSeen: Date.now(),
+            id: payload.workspaceId,
+            userId: this.loggedUser.id
           }
-        }
-      } catch (e) {
-        console.warn(
-          `Stored cookies (${COOKIES_CURRENT_WORKSPACE}) value is malformed, removing it.`,
-          e
-        )
-        // stored cookies value is malformed, remove it
-        cookies.remove(COOKIES_CURRENT_WORKSPACE)
-      }
-      return value
-    },
-
-    async getUserWorkspaceFromCookies() {
-      let userWorkspaceId: string
-      if (this.loggedUser?.username) {
-        try {
-          const value = await this.getAllUserWorkspacesFromCookies()
-          if (value) {
-            userWorkspaceId = value[this.loggedUser?.username]
-          }
-        } catch {
-          // ignore
-        }
-      }
-      return userWorkspaceId
-    },
-
-    async removeUserWorkspaceFromCookies() {
-      if (this.loggedUser?.username) {
-        let value: Record<string, string>
-        try {
-          value = await this.getAllUserWorkspacesFromCookies()
-        } catch {
-          // ignore
-        }
-
-        if (value) {
-          delete value[this.loggedUser?.username]
-          const strValue = JSON.stringify(value)
-
-          const expires = new Date()
-          // cookies expire in one year
-          expires.setFullYear(expires.getFullYear() + 1)
-          cookies.set(COOKIES_CURRENT_WORKSPACE, strValue, {
-            expires
-          })
-        }
+        ]
       }
     },
 
-    async setUserWorkspaceToCookies(payload) {
-      if (this.loggedUser?.username) {
-        let oldValue: Record<string, string>
-        try {
-          oldValue = await this.getAllUserWorkspacesFromCookies()
-        } catch {
-          // ignore
-        }
+    getLastWorkspaceFromStorage(): WorkspaceResponse | undefined {
+      if (this.loggedUser?.id === undefined) return
 
-        const value = JSON.stringify({
-          ...oldValue,
-          [this.loggedUser?.username]: payload.id
+      const lastSeenWorkspace = [...this.lastWorkspaces.value]
+        .sort((a, b) => {
+          return b.lastSeen - a.lastSeen
         })
-        const expires = new Date()
-        // cookies expire in one year
-        expires.setFullYear(expires.getFullYear() + 1)
-        cookies.set(COOKIES_CURRENT_WORKSPACE, value, {
-          expires
-        })
-      }
+        .find((item) => item.userId === this.loggedUser?.id)
+
+      return (
+        lastSeenWorkspace && this.getWorkspaceById({ id: lastSeenWorkspace.id })
+      )
     },
 
-    async setFirstWorkspace() {
-      if (this.workspaces.length > 0) {
-        await this.setWorkspace({
-          workspaceId: this.workspaces[0].id
-        })
-      }
+    async cleanupLastSeenWorkspaces() {
+      this.lastWorkspaces.value = this.lastWorkspaces.value.filter(
+        (item) => item.userId !== this.loggedUser?.id
+      )
     },
 
+    /**
+     * Checks the current workspace that the user is in.
+     *
+     * Tries to get the current workspace ID from the cookies.
+     * If not found, tries to use the preferred workspace ID from the user profile.
+     * If still not found, defaults to using the first workspace in the user's list of workspaces.
+     *
+     * Sets the current workspace in the store, and saves to cookies if needed.
+     */
     async checkCurrentWorkspace() {
       try {
         await this.getWorkspaces()
-        const currentWorkspaceFromCookie =
-          await this.getUserWorkspaceFromCookies()
+        let foundWorkspace = this.getLastWorkspaceFromStorage()
         if (this.workspaces.length > 0) {
-          let foundWorkspace
           let skipSavingInCookies = true
-          if (currentWorkspaceFromCookie !== undefined) {
-            // try to use workspace stored in cookies
-            foundWorkspace = this.getWorkspaceById({
-              id: parseInt(currentWorkspaceFromCookie)
-            })
-          }
           if (!foundWorkspace) {
             // try to use preferred_workspace from user profile response
-            const preferredWorkspaceId = await this.getPreferredWorkspaceId()
-            if (preferredWorkspaceId) {
-              foundWorkspace = this.getWorkspaceById({
-                id: preferredWorkspaceId
-              })
-              if (foundWorkspace?.id) {
-                // do not skip saving in cookies when using preferredWorkspace
-                skipSavingInCookies = false
-              }
+            const preferredWorkspaceId = this.loggedUser?.preferred_workspace
+            foundWorkspace = this.getWorkspaceById({
+              id: preferredWorkspaceId
+            })
+            if (foundWorkspace?.id) {
+              // do not skip saving in cookies when using preferredWorkspace
+              skipSavingInCookies = false
             }
           }
           // use id from found workspace, if not found fallback to first workspace from user workspaces
@@ -534,13 +454,13 @@ export const useUserStore = defineStore('userModule', {
             foundWorkspace?.id ?? this.workspaces[0].id
           await this.setWorkspace({
             workspaceId: currentWorkspaceIdToSet,
-            // do not save workspaceId to cookies as it could be:
+            // do not save workspaceId to storage as it could be:
             // * already there, if was loaded from cookies
             // * used the first user workspace as fallback, then it is not a user choice
             skipSavingInCookies
           })
         } else {
-          await this.removeUserWorkspaceFromCookies()
+          await this.cleanupLastSeenWorkspaces()
         }
       } catch (e) {
         console.warn('Loading of stored user workspace id has failed.', e)

--- a/web-app/packages/lib/src/modules/user/types.ts
+++ b/web-app/packages/lib/src/modules/user/types.ts
@@ -131,7 +131,7 @@ export interface IsWorkspaceAdminPayload {
 
 export interface SetWorkspaceIdPayload {
   workspaceId: number
-  skipSavingInCookies?: boolean
+  skipStorage?: boolean
 }
 
 export interface DeleteAccountConfirmProps {

--- a/web-app/packages/lib/src/modules/user/types.ts
+++ b/web-app/packages/lib/src/modules/user/types.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 
-import { Route } from 'vue-router'
+import { RouteRecordRaw } from 'vue-router'
 
 import { PaginatedRequestParams } from '@/common'
 import { UserRoleName } from '@/common/permission_utils'
@@ -15,7 +15,7 @@ export interface LoginData {
 
 export interface LoginPayload extends MerginComponentUuidPayload {
   data: LoginData
-  currentRoute: Route
+  currentRoute: RouteRecordRaw
 }
 
 export interface ResetPasswordPayload extends MerginComponentUuidPayload {
@@ -137,5 +137,12 @@ export interface SetWorkspaceIdPayload {
 export interface DeleteAccountConfirmProps {
   username: string
 }
+
+export interface LastSeenWorkspace {
+  userId: number
+  id: number
+  lastSeen: number
+}
+
 
 /* eslint-enable camelcase */


### PR DESCRIPTION
**Details**

Reaction to ticket https://github.com/MerginMaps/server-private/issues/2229

:hammer: 
 Store last seen workspace(s) in local storage instead of cookies. This PR is mostly only refactor, but following improvements are coming:
 
 - local storage is more robust than cookies
 - currentWorkspace cookies will not be sending in every request on API :1st_place_medal: 
 - there is not need to handle expiring of cookies
 - last workspace will be array instead key value (used for showing last seen workspace to user)
 
:heavy_plus_sign: New feature:

- We can now use Proxy based storing to local storage with ability to set value and sync it with localStorage. In case of array value in Proxy, use spread operator (push/pop ... are not reactive). This is experimental feature.

```javascript
const storage = createStorage('name-of-key', 0)

storage.value = 1
```