### PR TITLE
Collaborators management based on global variables

### DIFF
--- a/web-app/packages/app/src/modules/project/views/ProjectCollaboratorsView.vue
+++ b/web-app/packages/app/src/modules/project/views/ProjectCollaboratorsView.vue
@@ -8,9 +8,13 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
   <project-collaborators-view-template
     v-if="isProjectOwner"
     @share="openShareDialog"
-    :allow-share="!instanceStore.globalRolesEnabled"
+    :allow-share="instanceStore.currentGlobalRole === undefined"
     :show-access-requests="userStore.isGlobalWorkspaceAdmin"
-  />
+  >
+    <project-members-table
+      :allow-remove="instanceStore.currentGlobalRole === undefined"
+    />
+  </project-collaborators-view-template>
 </template>
 
 <script setup lang="ts">
@@ -22,7 +26,8 @@ import {
   useUserStore,
   useInstanceStore,
   useNotificationStore,
-  errorUtils
+  errorUtils,
+  ProjectMembersTable
 } from '@mergin/lib'
 import { computed } from 'vue'
 

--- a/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/_extensions.scss
+++ b/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/_extensions.scss
@@ -60,19 +60,11 @@ input, textarea {
   }
 }
 .p-chips {
-    &:not(.p-disabled).p-focus {
-      .p-chips-multiple-container {
-        box-shadow: inset 0 0 0 1px $primaryDarkColor;
-      }
+  &:not(.p-disabled).p-focus {
+    .p-chips-multiple-container {
+      box-shadow: inset 0 0 0 1px $primaryDarkColor;
     }
   }
-
-.text-color-medium-green {
-  color: map-get($colors, 'medium-green');
-}
-
-.overflow-wrap-anywhere {
-  overflow-wrap: anywhere;
 }
 
 .p-tooltip {
@@ -83,6 +75,17 @@ input, textarea {
   .p-tooltip-text {
     white-space: normal;
   }
+}
+
+
+// Custom semantic  classes
+
+.text-color-medium-green {
+  color: map-get($colors, 'medium-green');
+}
+
+.overflow-wrap-anywhere {
+  overflow-wrap: anywhere;
 }
 
 // Color of error messages in inputs ...

--- a/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/_variables.scss
+++ b/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/_variables.scss
@@ -34,7 +34,8 @@ $colors: (
     "forest": #004C45,
     "rose": #FFBABC,
     "field": #9BD1A9,
-    "sky": #A6CBF4
+    "sky": #A6CBF4,
+    "informative": #BEDAF0
 );
 
 // Mandatory Designer Variables

--- a/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/variables/_button.scss
+++ b/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/variables/_button.scss
@@ -120,11 +120,11 @@ $secondaryButtonFocusShadow: 0 0 0 0.2rem map-get($map: $colors, $key: "medium-g
 
 /// Background of an info button
 /// @group button
-$infoButtonBg: #03A9F4;
+$infoButtonBg: map-get($map: $colors, $key: informative);
 
 /// Text color of an info button
 /// @group button
-$infoButtonTextColor: #ffffff;
+$infoButtonTextColor: map-get($map: $colors, $key: "deep-ocean");
 
 /// Border of an info button
 /// @group button

--- a/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/variables/_form.scss
+++ b/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/variables/_form.scss
@@ -8,7 +8,7 @@ $inputBg: #ffffff;
 
 /// Font size of an input field
 /// @group form
-$inputTextFontSize: 0.90rem;
+$inputTextFontSize: 0.875rem;
 
 /// Text color of an input field
 /// @group form

--- a/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/variables/_form.scss
+++ b/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/variables/_form.scss
@@ -161,7 +161,7 @@ $inputOverlayBorder: 0 none;
 
 /// Shadow for an overlay of an input such as autocomplete or dropdown
 /// @group form
-$inputOverlayShadow: 0 3px 6px 0 rgba(0, 0, 0, 0.1);
+$inputOverlayShadow: 0px 12px 24px rgba(0, 76, 69, 0.15);
 
 /// Width of a checkbox
 /// @group form

--- a/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/variables/_menu.scss
+++ b/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/variables/_menu.scss
@@ -144,7 +144,7 @@ $overlayMenuBorder: 0 none;
 
 /// Box shadow of an overlay menu
 /// @group menu
-$overlayMenuShadow: 0 1px 6px 0 rgba(0, 0, 0, 0.1);
+$overlayMenuShadow: 0px 12px 24px rgba(0, 76, 69, 0.15);
 
 /// Padding of a vertical menu e.g. tieredmenu, contextmenu
 /// @group menu

--- a/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/variables/_overlay.scss
+++ b/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/variables/_overlay.scss
@@ -8,7 +8,7 @@ $overlayContentBg:$panelContentBg;
 
 /// Box shadow of an overlay container element such as dialog or overlaypanel
 /// @group overlay
-$overlayContainerShadow: 0 0 14px 0 rgba(0, 0, 0, 0.1);
+$overlayContainerShadow: 0px 12px 24px rgba(0, 76, 69, 0.15);
 
 /// Background of a dialog header
 /// @group overlay

--- a/web-app/packages/lib/src/common/components/AppDropdown.vue
+++ b/web-app/packages/lib/src/common/components/AppDropdown.vue
@@ -9,6 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
     :options="options"
     option-label="label"
     option-value="value"
+    option-disabled="disabled"
     v-model="model"
     @show="toggle"
     @hide="toggle"
@@ -26,7 +27,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
       item({ context }) {
         return {
           class: [
-            'text-color p-2 hover:bg-gray-100 bg-transparent',
+            'text-color hover:bg-gray-100 bg-transparent',
             context.focused ? 'bg-gray-50' : 'bg-transparent'
           ]
         }
@@ -36,6 +37,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
           class: options.props?.disabled ? 'text-color' : 'text-color-forest'
         }
       },
+      list: 'p-0',
       panel: {
         style: {
           zIndex: 2101
@@ -53,6 +55,11 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         ]"
       ></i>
     </template>
+    <template #value="{ value, placeholder }">{{
+      options.find((item) => item.value === value).label ??
+      placeholder ??
+      '&nbsp;'
+    }}</template>
     <template #option="{ option }">
       <div class="flex paragraph-p6 align-items-center">
         <div class="flex flex-column mr-6">

--- a/web-app/packages/lib/src/common/components/AppDropdown.vue
+++ b/web-app/packages/lib/src/common/components/AppDropdown.vue
@@ -22,7 +22,11 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         }
       },
       input: {
-        class: 'paragraph-p6 border-round-xl'
+        class: 'paragraph-p6 border-round-xl',
+        style: {
+          paddingTop: '.625rem',
+          paddingBottom: '.625rem'
+        }
       },
       item({ context }) {
         return {

--- a/web-app/packages/lib/src/common/components/AppDropdown.vue
+++ b/web-app/packages/lib/src/common/components/AppDropdown.vue
@@ -56,7 +56,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
       ></i>
     </template>
     <template #value="{ value, placeholder }">{{
-      options.find((item) => item.value === value).label ??
+      options?.find((item) => item.value === value)?.label ??
       placeholder ??
       '&nbsp;'
     }}</template>

--- a/web-app/packages/lib/src/common/components/AppSidebarRight.vue
+++ b/web-app/packages/lib/src/common/components/AppSidebarRight.vue
@@ -9,6 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
     <PSidebar
       :auto-z-index="false"
       v-model:visible="model"
+      block-scroll
       :modal="true"
       position="right"
       class="w-11 lg:w-5 xl:w-3"

--- a/web-app/packages/lib/src/common/permission_utils.ts
+++ b/web-app/packages/lib/src/common/permission_utils.ts
@@ -21,6 +21,12 @@ export enum ProjectRole {
   owner
 }
 
+export enum GlobalRole {
+  global_read,
+  global_write,
+  global_admin
+}
+
 export type UserRoleName = 'guest' | 'reader' | 'writer' | 'admin' | 'owner'
 
 export type ProjectRoleName =
@@ -59,11 +65,6 @@ export const PROJECT_ROLE_BY_NAME: Record<ProjectRoleName, ProjectRole> = {
   owner: ProjectRole.owner
 }
 
-export interface UserRoleValueForSelect {
-  label: string
-  value: UserRoleName
-}
-
 export enum ProjectPermission {
   read,
   write,
@@ -88,11 +89,6 @@ export const PROJECT_PERMISSION_BY_NAME: Record<
   owner: ProjectPermission.owner
 }
 
-export interface ProjectPermissionValueForSelect {
-  label: string
-  value: ProjectPermissionName
-}
-
 export function isAtLeastRole(roleName: UserRoleName, role: UserRole): boolean {
   return USER_ROLE_BY_NAME[roleName] >= role
 }
@@ -111,12 +107,21 @@ export function isAtLeastProjectPermission(
   return PROJECT_PERMISSION_BY_NAME[permissionName] >= permission
 }
 
+export function isAtLeastGlobalRole(
+  roleName: ProjectRoleName,
+  globalRole: GlobalRole
+): boolean {
+  // We have also none role, so we need to add 1 to the global role
+  return PROJECT_ROLE_BY_NAME[roleName] >= globalRole + 1
+}
+
 export function getProjectRoleNameValues(): DropdownOption<ProjectRoleName>[] {
   return [
     {
       value: 'reader',
       label: 'Reader',
-      description: 'Can view project files'
+      description: 'Can view project files',
+      disabled: true
     },
     {
       value: 'writer',

--- a/web-app/packages/lib/src/modules/instance/store.ts
+++ b/web-app/packages/lib/src/modules/instance/store.ts
@@ -12,6 +12,7 @@ import {
 } from '@/modules/instance/types'
 import { useNotificationStore } from '@/modules/notification/store'
 import { useUserStore } from '@/modules/user/store'
+import { GlobalRole, isAtLeastGlobalRole } from '@/common/permission_utils'
 
 export interface InstanceState {
   initData: InitResponse
@@ -30,14 +31,22 @@ export const useInstanceStore = defineStore('instanceModule', {
 
   getters: {
     /**
-     * Checks if global roles are enabled based on the config data.
-     * Returns true if any of the global role flags are truthy, false otherwise.
+     * Retrieves the current global role from the instance configuration data.
+     *
+     * The global role is determined by checking the `global_read`, `global_write`, and `global_admin` flags in the configuration data.
+     * If none of the flags are set, `undefined` is returned, otherwise the index of the first set flag is returned as the global role.
+     *
+     * @param state - The current instance state.
+     * @returns The current global role, or `undefined` if no global role is set.
      */
-    globalRolesEnabled(state): boolean {
+    currentGlobalRole(state): GlobalRole | undefined {
       // eslint-disable-next-line camelcase
       const { global_read, global_write, global_admin } = state.configData
       // eslint-disable-next-line camelcase
-      return [global_read, global_write, global_admin].some((r) => !!r)
+      const foundIndex = [global_read, global_write, global_admin].findIndex(
+        (r) => !!r
+      )
+      return foundIndex < 0 ? undefined : foundIndex
     }
   },
 

--- a/web-app/packages/lib/src/modules/instance/store.ts
+++ b/web-app/packages/lib/src/modules/instance/store.ts
@@ -4,6 +4,7 @@
 
 import { defineStore } from 'pinia'
 
+import { GlobalRole } from '@/common/permission_utils'
 import { InstanceApi } from '@/modules/instance/instanceApi'
 import {
   ConfigResponse,
@@ -12,7 +13,6 @@ import {
 } from '@/modules/instance/types'
 import { useNotificationStore } from '@/modules/notification/store'
 import { useUserStore } from '@/modules/user/store'
-import { GlobalRole, isAtLeastGlobalRole } from '@/common/permission_utils'
 
 export interface InstanceState {
   initData: InitResponse

--- a/web-app/packages/lib/src/modules/project/components/FileChangesetSummaryTable.vue
+++ b/web-app/packages/lib/src/modules/project/components/FileChangesetSummaryTable.vue
@@ -20,7 +20,11 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
     >
       <template #header>
         <div class="grid grid-nogutter">
-          <div v-for="col in columns" class="col-3 paragraph-p6" :key="col.text">
+          <div
+            v-for="col in columns"
+            class="col-3 paragraph-p6"
+            :key="col.text"
+          >
             <i
               v-if="col.icon"
               :class="['ti', `${col.icon}`]"

--- a/web-app/packages/lib/src/modules/project/components/ProjectAccessRequests.vue
+++ b/web-app/packages/lib/src/modules/project/components/ProjectAccessRequests.vue
@@ -26,7 +26,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
         <div
           class="flex flex-column lg:flex-row align-items-center justify-content-between px-4 py-2 mt-0 border-bottom-1 border-gray-200"
         >
-          <p class="w-12 lg:w-4 paragraph-p6 m-0">
+          <p class="w-12 lg:w-6 paragraph-p6 m-0">
             User
             <span class="font-semibold">{{ item.requested_by }}</span>
             requested an access to your project

--- a/web-app/packages/lib/src/modules/project/components/ProjectAccessRequests.vue
+++ b/web-app/packages/lib/src/modules/project/components/ProjectAccessRequests.vue
@@ -54,7 +54,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             />
             <div class="flex justify-content-end w-6 lg:w-4">
               <PButton
-                :disabled="!canCancelAccessRequest(item.user?.id)"
+                :disabled="!canCancelAccessRequest()"
                 icon="ti ti-x"
                 rounded
                 aria-label="Disallow"
@@ -63,7 +63,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
                 @click="cancelRequest(item)"
               />
               <PButton
-                :disabled="!canAcceptAccessRequest(item.user?.id, item.expire)"
+                :disabled="!canAcceptAccessRequest(item.expire)"
                 icon="ti ti-check"
                 rounded
                 aria-label="Accept"
@@ -145,18 +145,14 @@ export default defineComponent({
       }
       await this.fetchItems()
     },
-    canAcceptAccessRequest(userId: number, expire: string) {
+    canAcceptAccessRequest(expire: string) {
       return (
         !this.expired(expire) &&
-        this.project.creator !== userId &&
         isAtLeastProjectRole(this.project.role, ProjectRole.owner)
       )
     },
-    canCancelAccessRequest(userId: number) {
-      return (
-        this.project.creator !== userId &&
-        isAtLeastProjectRole(this.project.role, ProjectRole.owner)
-      )
+    canCancelAccessRequest() {
+      return isAtLeastProjectRole(this.project.role, ProjectRole.owner)
     },
     async acceptRequest(request) {
       try {

--- a/web-app/packages/lib/src/modules/project/components/ProjectMembersTable.vue
+++ b/web-app/packages/lib/src/modules/project/components/ProjectMembersTable.vue
@@ -32,7 +32,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
           </div>
         </template>
 
-        <!-- table rows -->
+        <!-- table rows -->options
         <template #list="slotProps">
           <div
             v-for="item in slotProps.items"
@@ -79,9 +79,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
                     :options="roles"
                     :model-value="item.project_permission"
                     @update:model-value="(e) => roleUpdate(item, e)"
-                    :disabled="
-                      item.id === loggedUser.id || item.id === project.creator
-                    "
+                    :disabled="item.id === loggedUser.id"
                     class="w-6 lg:w-full"
                   />
                   <span v-else
@@ -104,9 +102,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
                 @click.stop="removeMember(item)"
                 class="paragraph-p3 p-0"
                 :style="{
-                  visibility: projectStore.canRemoveProjectAccess(item)
-                    ? 'visible'
-                    : 'hidden'
+                  visibility: canRemoveMember(item) ? 'visible' : 'hidden'
                 }"
               />
             </div>
@@ -126,16 +122,18 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 import { computed, ref, onUnmounted } from 'vue'
 
 import { useProjectStore } from '../store'
-import { ProjectAccessDetail, SortingParams } from '../types'
+import { ProjectAccessDetail } from '../types'
 
 import AppContainer from '@/common/components/AppContainer.vue'
 import AppDropdown from '@/common/components/AppDropdown.vue'
 import AppSection from '@/common/components/AppSection.vue'
 import {
+  GlobalRole,
   ProjectRoleName,
-  getProjectRoleNameValues
+  getProjectRoleNameValues,
+  isAtLeastGlobalRole
 } from '@/common/permission_utils'
-import { useUserStore } from '@/main'
+import { useInstanceStore, useUserStore } from '@/main'
 
 // TODO: Externalize to AppCol element
 interface ColumnItem {
@@ -146,10 +144,15 @@ interface ColumnItem {
   textClass?: string
 }
 
+interface Props {
+  allowRemove?: boolean
+}
+
 const projectStore = useProjectStore()
 const userStore = useUserStore()
+const instanceStore = useInstanceStore()
 
-defineProps<{ options?: SortingParams }>()
+const props = withDefaults(defineProps<Props>(), { allowRemove: true })
 
 const itemsPerPage = ref(10)
 const columns = ref<ColumnItem[]>([
@@ -175,9 +178,16 @@ const columns = ref<ColumnItem[]>([
     fixed: true
   }
 ])
-const roles = ref(getProjectRoleNameValues())
+const roles = computed(() =>
+  getProjectRoleNameValues().map((item) => ({
+    ...item,
+    disabled: !isAtLeastGlobalRole(
+      item.value,
+      instanceStore.currentGlobalRole ?? GlobalRole.global_read
+    )
+  }))
+)
 const loggedUser = computed(() => userStore.loggedUser)
-const project = computed(() => projectStore.project)
 const searchedItems = computed(() =>
   projectStore.access.filter((item) => {
     return [item.username, item.email].some(
@@ -185,6 +195,10 @@ const searchedItems = computed(() =>
     )
   })
 )
+
+function canRemoveMember(item: ProjectAccessDetail) {
+  return props.allowRemove && item.id !== loggedUser.value?.id
+}
 
 function removeMember(item: ProjectAccessDetail) {
   projectStore.removeProjectAccess(item)

--- a/web-app/packages/lib/src/modules/project/store.ts
+++ b/web-app/packages/lib/src/modules/project/store.ts
@@ -95,28 +95,7 @@ export const useProjectStore = defineStore('projectModule', {
 
   getters: {
     isProjectOwner: (state) =>
-      isAtLeastProjectRole(state.project?.role, ProjectRole.owner),
-    getProjectByName(state) {
-      return (payload) => {
-        return state.projects?.find((project) => project.name === payload.name)
-      }
-    },
-
-    /**
-     * Checks if the current user can remove the given project access detail.
-     *
-     * The user must be at least a project owner, and the access detail ID cannot
-     * be the same as the project creator ID.
-     *
-     * @param payload - The project access detail to check
-     * @returns True if the current user can remove the given access, false otherwise
-     */
-    canRemoveProjectAccess: (state) => (payload: ProjectAccessDetail) => {
-      return (
-        isAtLeastProjectRole(state.project?.role, ProjectRole.owner) &&
-        payload.id !== state.project?.creator
-      )
-    }
+      isAtLeastProjectRole(state.project?.role, ProjectRole.owner)
   },
 
   actions: {

--- a/web-app/packages/lib/src/modules/user/types.ts
+++ b/web-app/packages/lib/src/modules/user/types.ts
@@ -144,5 +144,4 @@ export interface LastSeenWorkspace {
   lastSeen: number
 }
 
-
 /* eslint-enable camelcase */


### PR DESCRIPTION
Resolves #2230 in private repo

Scope: Make logic with GLOBAL_READ, GLOBAL_WRITE and GLOBAL_ADMIN variables to collaborators tab.

![image](https://github.com/MerginMaps/server/assets/12643115/bf6e96c8-17da-4357-bc24-3747df59cb72)

Enh: :hammer: 

- allow disable items in app-dropdown
- allow choosing role that makes sense
- disable removing collaborators in case of GLOBAL_* variables are enabled
- remove some project.creator checks

Design :rose: 

- add box-shadow for menus and drop downs copied from design system figma
- add informative tag

:question: 

- @varmar05  do we want to update some endpoints logic?