### PR TITLE
Fix: .prod.env variables LOCAL_PROJECTS,TEMP_DIR

### DIFF
--- a/.prod.env
+++ b/.prod.env
@@ -8,8 +8,8 @@ CONTACT_EMAIL=fixme
 
 #DEBUG=FLASK_DEBUG | False
 
-#LOCAL_PROJECTS=/data/live
-LOCAL_PROJECTS=os.path.join(config_dir, os.pardir, os.pardir, 'projects')  # for local storage type
+#LOCAL_PROJECTS=os.path.join(config_dir, os.pardir, os.pardir, 'projects')  # for local storage type
+LOCAL_PROJECTS=/data
 
 #MAINTENANCE_FILE=os.path.join(LOCAL_PROJECTS, 'MAINTENANCE')  # locking file when backups are created
 MAINTENANCE_FILE=/data/MAINTENANCE
@@ -23,8 +23,8 @@ SECRET_KEY=fixme
 
 #SWAGGER_UI=False  # to enable swagger UI console (for test only)
 
-#TEMP_DIR=/data/tmp
-TEMP_DIR=gettempdir()  # trash dir for temp files being cleaned regularly
+#TEMP_DIR=gettempdir()  # trash dir for temp files being cleaned regularly
+TEMP_DIR=/data/tmp
 
 #TESTING=False
 


### PR DESCRIPTION
:hammer: Fix:

- variables in .prod.env
- default value in production environment is correctly mapped to ```docker-compose.yml``` volume for server container

**How to test**

Follow instructions in: https://merginmaps.com/docs/dev/mergince/#deployment

```bash
mkdir -p projects
sudo chown -R  901:999 ./projects/
sudo chmod g+s ./projects/
docker compose -f docker-compose.yml up -d
```