### PR TITLE
Filter active users in collaborators

### DIFF
--- a/server/mergin/sync/private_api_controller.py
+++ b/server/mergin/sync/private_api_controller.py
@@ -360,7 +360,7 @@ def get_project_access(id: str):
                 )
                 processed_ids.add(user_id)
     if global_role:
-        for user in User.query.all():
+        for user in User.query.filter_by(active=True).all():
             if user.id not in processed_ids:
                 result.append(
                     {

--- a/server/mergin/tests/test_private_project_api.py
+++ b/server/mergin/tests/test_private_project_api.py
@@ -515,3 +515,10 @@ def test_get_project_access(client):
     assert sum(map(lambda x: int(x["project_permission"] == "owner"), resp.json)) == 6
     assert sum(map(lambda x: int(x["project_permission"] == "writer"), resp.json)) == 0
     assert sum(map(lambda x: int(x["project_permission"] == "reader"), resp.json)) == 0
+    # pretend a user was deleted to test that api can handle it
+    users[3].inactivate()
+    users[3].anonymize()
+    resp = client.get(url)
+    assert resp.status_code == 200
+    assert len(resp.json) == 5
+    assert sum(map(lambda x: int(x["project_permission"] == "owner"), resp.json)) == 5


### PR DESCRIPTION
fixes: https://github.com/MerginMaps/server-private/issues/2303

If a user is deleted and a global role is set, project-access api fails as it wants to add a deleted user who doesn't have an email. The solution is to filter only active users from the DB to be added to the response.