### PR TITLE
Fix: Prevent download of inactive ws zip (without 500)

### DIFF
--- a/server/mergin/sync/permissions.py
+++ b/server/mergin/sync/permissions.py
@@ -160,22 +160,22 @@ class ProjectPermissions:
 
 def is_active_workspace(workspace):
     """
-    Checks if the given workspace is active and if the current user is an admin or anonymous.
+    Checks if the given workspace is active or if the current user is an admin.
 
     Args:
         workspace (Workspace): The workspace to check.
 
     Returns:
-        bool: True if the workspace is not active and the current user is not an admin or is anonymous, False otherwise.
+        bool: True if the workspace is active or the current user is an admin, False otherwise.
     """
-    if not workspace:
-        abort(404)
     is_admin = not current_user.is_anonymous and current_user.is_admin
     return workspace.is_active or is_admin
 
 
 def require_project(ws, project_name, permission):
     workspace = current_app.ws_handler.get_by_name(ws)
+    if not workspace:
+        abort(404)
     if not is_active_workspace(workspace):
         abort(404, "Workspace doesn't exist")
     project = (
@@ -200,6 +200,8 @@ def require_project_by_uuid(uuid: str, permission: ProjectPermissions, scheduled
         project = project.filter(Project.removed_at.is_(None))
     project = project.first_or_404()
     workspace = project.workspace
+    if not workspace:
+        abort(404)
     if not is_active_workspace(workspace):
         abort(404, "Workspace doesn't exist")
     if not permission.check(project, current_user):

--- a/server/mergin/sync/permissions.py
+++ b/server/mergin/sync/permissions.py
@@ -157,15 +157,24 @@ class ProjectPermissions:
             return ProjectRole.READER
         return None
 
+def is_inactive_workspace(workspace):
+    """
+    Checks if the given workspace is active and if the current user is an admin or anonymous.
+
+    Args:
+        workspace (Workspace): The workspace to check.
+
+    Returns:
+        bool: True if the workspace is not active and the current user is not an admin or is anonymous, False otherwise.
+    """
+    is_admin = not current_user.is_anonymous and current_user.is_admin
+    if not workspace:
+        abort(404)
+    return not workspace.is_active and (not is_admin or is_anonymous)
 
 def require_project(ws, project_name, permission):
     workspace = current_app.ws_handler.get_by_name(ws)
-    if not workspace:
-        abort(404)
-    # Check for active workspace and if logged user (not Anonymous) is admin.
-    is_anonymous = isinstance(current_user, AnonymousUserMixin)
-    is_admin = not is_anonymous and current_user.is_admin
-    if not workspace.is_active and (not is_admin or is_anonymous):
+    if is_inactive_workspace(workspace):
         abort(404, "Workspace doesn't exist")
     project = (
         Project.query.filter_by(name=project_name, workspace_id=workspace.id)
@@ -189,9 +198,7 @@ def require_project_by_uuid(uuid: str, permission: ProjectPermissions, scheduled
         project = project.filter(Project.removed_at.is_(None))
     project = project.first_or_404()
     workspace = project.workspace
-    if not workspace:
-        abort(404)
-    if not workspace.is_active and not current_user.is_admin:
+    if is_inactive_workspace(workspace):
         abort(404, "Workspace doesn't exist")
     if not permission.check(project, current_user):
         abort(403, "You do not have permissions for this project")


### PR DESCRIPTION
Fixes https://github.com/MerginMaps/server-private/issues/2381

- prevent 500 error code for case where user is_anonymous and stayed on project tree page and trying to donwload file of inactive ws
- admin is still available to download such project

Error message now (workspace is not active, does not exists for users anymore):
![image](https://github.com/MerginMaps/server/assets/12643115/d09cabc0-1d83-498c-aff3-c65a5ab9b03b)