### PR TITLE
Adjust message banner colors based on design

### DIFF
--- a/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/variables/_message.scss
+++ b/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/variables/_message.scss
@@ -80,19 +80,19 @@ $toastDetailMargin: $inlineSpacing 0 0 0;
 
 /// Background of an info message
 /// @group message
-$infoMessageBg: #039BE5;
+$infoMessageBg: map-get($map: $colors, $key: informative);
 
 /// Border of an info message
 /// @group message
-$infoMessageBorder: solid #027cb7;
+$infoMessageBorder: 0 solid map-get($map: $colors, $key: deep-ocean);
 
 /// Text color of an info message
 /// @group message
-$infoMessageTextColor: #ffffff;
+$infoMessageTextColor: map-get($map: $colors, $key: deep-ocean);
 
 /// Icon color of an info message
 /// @group message
-$infoMessageIconColor: #ffffff;
+$infoMessageIconColor: map-get($map: $colors, $key: deep-ocean);
 
 /// Background of a success message
 /// @group message


### PR DESCRIPTION
Resolves https://github.com/MerginMaps/server-private/issues/2366

Adjust colors of the info message according to figma design.

Other messages are already fine. :white_flower: 

![image](https://github.com/MerginMaps/server/assets/28006188/ac7ddefb-03cc-45b4-8da7-8272f2795e8b)
