### PR TITLE
Add invitatation attribute with expires_at field to ProjectAccessDeta…

### DIFF
--- a/server/mergin/sync/schemas.py
+++ b/server/mergin/sync/schemas.py
@@ -342,6 +342,10 @@ class UserWorkspaceSchema(ma.SQLAlchemyAutoSchema):
         return obj.get_user_role(self.context.get("user"))
 
 
+class ProjectInvitationAccessSchema(Schema):
+    expires_at = fields.String()
+
+
 class StrOrInt(fields.Field):
     """Custom field type for validating both str or int datatype"""
 
@@ -360,3 +364,4 @@ class ProjectAccessDetailSchema(Schema):
     name = fields.String()
     project_permission = fields.String()
     type = fields.String()
+    invitation = fields.Nested(ProjectInvitationAccessSchema())


### PR DESCRIPTION
Fixes https://github.com/MerginMaps/server-private/issues/2442

We forgot taht in EE/SaaS this CE code has to know about invitations which are not present in CE.

Problem:

In SaaS, Project Collaborators tab we ddn't know when the invitation is expiring.


Solution

Add `expires_at` field for `invitation` attribute of the project access schema.


![image](https://github.com/user-attachments/assets/0fa7a1b7-dbb0-4c55-94d3-1a8ade25ec0e)