### PR TITLE
Set correct Content-Type for responses with custom error

### DIFF
--- a/server/mergin/app.py
+++ b/server/mergin/app.py
@@ -396,6 +396,15 @@ def create_app(public_keys: List[str] = None) -> Flask:
 
         return response
 
+    @application.after_request
+    def set_custom_error_header(response):
+        """Clients (e.g. plugin) expect error `Content-Type` in response header.
+        Some responses with custom error lacks it."""
+        if response.status_code == 422:
+            response.headers["Content-Type"] = "application/problem+json"
+
+        return response
+
     # we need to register default handler to be accessible within app
     application.ws_handler = GlobalWorkspaceHandler()
     application.project_handler = ProjectHandler()

--- a/server/mergin/sync/private_api.yaml
+++ b/server/mergin/sync/private_api.yaml
@@ -144,7 +144,7 @@ paths:
         "422":
           description: Reached user limit
           content:
-            application/json:
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/UsersLimitHit"
   /project/access-requests:

--- a/server/mergin/sync/public_api.yaml
+++ b/server/mergin/sync/public_api.yaml
@@ -272,7 +272,7 @@ paths:
         "422":
           description: Project access update could not be processed
           content:
-            application/json:
+            application/json+problem:
               schema:
                 anyOf:
                   - $ref: "#/components/schemas/UpdateProjectAccessError"
@@ -645,7 +645,7 @@ paths:
         "422":
           description: Request could not be processed by server
           content:
-            application/json:
+            application/problem+json:
               schema:
                 anyOf:
                   - $ref: "#/components/schemas/UnprocessableEntityError"
@@ -976,7 +976,7 @@ components:
     ProjectsLimitHitResp:
       description: Projects limit hit
       content:
-        application/json:
+        application/problem+json:
           schema:
             $ref: '#/components/schemas/ProjectsLimitHit'
   parameters:

--- a/server/mergin/sync/public_api.yaml
+++ b/server/mergin/sync/public_api.yaml
@@ -272,7 +272,7 @@ paths:
         "422":
           description: Project access update could not be processed
           content:
-            application/json+problem:
+            application/problem+json:
               schema:
                 anyOf:
                   - $ref: "#/components/schemas/UpdateProjectAccessError"

--- a/server/mergin/tests/test_project_controller.py
+++ b/server/mergin/tests/test_project_controller.py
@@ -680,6 +680,7 @@ def test_update_project(client):
         headers=json_headers,
     )
     assert resp.status_code == 422
+    assert resp.headers["Content-Type"] == "application/problem+json"
     assert resp.json["code"] == "UpdateProjectAccessError"
     assert resp.json["invalid_usernames"] == ["not-found-user"]
 
@@ -1252,6 +1253,7 @@ def test_exceed_data_limit(client):
         headers=json_headers,
     )
     assert resp.status_code == 422
+    assert resp.headers["Content-Type"] == "application/problem+json"
     assert resp.json["code"] == "StorageLimitHit"
     assert resp.json["detail"] == "You have reached a data limit (StorageLimitHit)"
     assert "current_usage" in resp.json


### PR DESCRIPTION
Fixes [#2459](https://github.com/MerginMaps/server-private/issues/2459)

Error handling in py-client was done here: https://github.com/MerginMaps/python-api-client/pull/209

Problem:
The 'incorrect' `Content-Type` is when response is not created with `abort` command. This happens when we want some custom attributes in error response. 

Solution:
Add desirable `Content-Type` with after_request decorator to all custom error responses.

Alternative solution could be to set `problem+json` for `Content-Type` when returning the request in the method.