### PR TITLE
Optimize file history queries using cached version names

### DIFF
--- a/server/mergin/sync/models.py
+++ b/server/mergin/sync/models.py
@@ -554,14 +554,13 @@ class FileHistory(db.Model):
         history = []
         full_history = (
             FileHistory.query.join(ProjectFilePath)
-            .join(FileHistory.version)
             .filter(
-                ProjectVersion.project_id == project_id,
-                ProjectVersion.name <= to,
-                ProjectVersion.name >= since,
+                ProjectFilePath.project_id == project_id,
+                FileHistory.project_version_name <= to,
+                FileHistory.project_version_name >= since,
                 ProjectFilePath.path == file,
             )
-            .order_by(desc(ProjectVersion.created))
+            .order_by(desc(FileHistory.project_version_name))
             .all()
         )
 

--- a/server/mergin/sync/public_api_controller.py
+++ b/server/mergin/sync/public_api_controller.py
@@ -330,13 +330,12 @@ def download_project_file(
     # find the latest file change record for version of interest
     fh = (
         FileHistory.query.join(ProjectFilePath)
-        .join(ProjectVersion)
         .filter(
-            ProjectVersion.project_id == project.id,
-            ProjectVersion.name <= lookup_version,
+            ProjectFilePath.project_id == project.id,
+            FileHistory.project_version_name <= lookup_version,
             ProjectFilePath.path == file,
         )
-        .order_by(ProjectVersion.created.desc())
+        .order_by(FileHistory.project_version_name.desc())
         .first()
     )
     # in case last change was 'delete', file does not exist for such version


### PR DESCRIPTION
Simplify queries of file history so that JOIN with project version table is not needed. 

Tested on selected project with up to 50x speed up.