### PR TITLE
Keep project versions for removed projects

### DIFF
--- a/server/mergin/sync/models.py
+++ b/server/mergin/sync/models.py
@@ -209,7 +209,7 @@ class Project(db.Model):
     def delete(self, removed_by: int = None):
         """Mark project as permanently deleted (but keep in db)
         - rename (to free up the same name)
-        - remove associated files and their history and project versions
+        - remove associated files and their history
         - reset project_access
         - decline pending project access requests
         """
@@ -225,9 +225,7 @@ class Project(db.Model):
         # Null in storage params serves as permanent deletion flag
         self.storage.delete()
         self.storage_params = null()
-        pv_table = ProjectVersion.__table__
-        # remove versions and file history items with cascade
-        db.session.execute(pv_table.delete().where(pv_table.c.project_id == self.id))
+        # remove file records and their history (cascade)
         files_path_table = ProjectFilePath.__table__
         db.session.execute(
             files_path_table.delete().where(files_path_table.c.project_id == self.id)

--- a/server/mergin/tests/test_celery.py
+++ b/server/mergin/tests/test_celery.py
@@ -133,5 +133,5 @@ def test_remove_deleted_project_backups(client):
         .filter(Project.storage_params.isnot(None))
         .first()
     )
-    assert ProjectVersion.query.filter_by(project_id=rm_project.id).count() == 0
+    assert ProjectVersion.query.filter_by(project_id=rm_project.id).count() != 0
     assert str(rm_project.id) in rm_project.name

--- a/server/mergin/tests/test_db_hooks.py
+++ b/server/mergin/tests/test_db_hooks.py
@@ -142,15 +142,15 @@ def test_remove_project(client, diff_project):
     diff_project.delete()
     assert Project.query.filter_by(id=project_id).count()
     assert not Upload.query.filter_by(project_id=project_id).count()
-    assert not ProjectVersion.query.filter_by(project_id=project_id).count()
+    assert ProjectVersion.query.filter_by(project_id=project_id).count()
     assert ProjectAccess.query.filter_by(project_id=project_id).count()
     cleanup(client, [project_dir])
     assert access_request.status == RequestStatus.DECLINED.value
-    # after removal only cached information in project table remains
+    # after removal cached information in project table remains and project versions, but not files details
     assert diff_project.disk_usage
     assert diff_project.latest_version is not None
     assert diff_project.files == []
-    assert not diff_project.get_latest_version()
+    assert diff_project.get_latest_version()
     assert (
         FileHistory.query.filter(FileHistory.version_id.in_(versions_ids)).count() == 0
     )


### PR DESCRIPTION
Now when project version table became lightweight we want to keep it even for removed projects. Files details are still removed.