### PR TITLE
Reject upload early

### DIFF
--- a/server/mergin/sync/models.py
+++ b/server/mergin/sync/models.py
@@ -29,6 +29,7 @@ from .files import (
     ChangesSchema,
     ProjectFile,
 )
+from .storages.disk import move_to_tmp
 from .. import db
 from .storages import DiskStorage
 from .utils import is_versioned_file, is_qgis
@@ -1041,6 +1042,14 @@ class Upload(db.Model):
             time.time() - os.path.getmtime(self.lockfile)
             < current_app.config["LOCKFILE_EXPIRATION"]
         )
+
+    def clear(self):
+        """Clean up pending upload.
+        Uploaded files and table records are removed, and another upload can start.
+        """
+        move_to_tmp(self.upload_dir, self.id)
+        db.session.delete(self)
+        db.session.commit()
 
 
 class RequestStatus(Enum):

--- a/server/mergin/sync/utils.py
+++ b/server/mergin/sync/utils.py
@@ -301,27 +301,6 @@ def split_project_path(project_path):
     return workspace_name, project_name
 
 
-def clean_upload(transaction_id):
-    """Clean upload infrastructure
-
-    Uploaded files and table records are removed, and another upload can be started.
-
-    :param transaction_id: Transaction id.
-    :type transaction_id: Str
-
-    :rtype: None
-    """
-    from mergin.sync.permissions import get_upload
-    from mergin.sync.storages.disk import move_to_tmp
-    from .. import db
-
-    upload, upload_dir = get_upload(transaction_id)
-    db.session.delete(upload)
-    db.session.commit()
-    move_to_tmp(upload_dir, transaction_id)
-    return NoContent, 200
-
-
 def get_device_id(request: Request) -> Optional[str]:
     """Get device uuid from http header X-Device-Id"""
     return request.headers.get("X-Device-Id")


### PR DESCRIPTION
In current setup we reject upload only if it cannot be pushed to db which is good and cover a lot of cases (e.g. race conditions) but sometimes there are many requests coming to backend in very short time - for those we want to reject upload requests as early as possible to save some resources on server.