### PR TITLE
Introduce more celery variables

### DIFF
--- a/.prod.env
+++ b/.prod.env
@@ -129,9 +129,9 @@ CELERY_RESULT_BACKEND_TRANSPORT_OPTIONS={ 'master_name': 'mymaster' }
 #CELERY_ACKS_LATE=False
 
 #CELERY_WORKER_CONCURRENCY=1 # set to number of cpu in case of prefork or to higher number in case of gevent pool
-CELERY_WORKER_CONCURRENCY=2
+CELERYD_CONCURRENCY=2
 
-#CELERY_WORKER_PREFETCH_MULTIPLIER=4
+#CELERYD_PREFETCH_MULTIPLIER=4
 
 # various life times
 

--- a/.prod.env
+++ b/.prod.env
@@ -126,6 +126,12 @@ CELERY_RESULT_BACKEND=redis://merginmaps-redis:6379/0
 #CELERY_RESULT_BACKEND_TRANSPORT_OPTIONS={}  # cast=eval
 CELERY_RESULT_BACKEND_TRANSPORT_OPTIONS={ 'master_name': 'mymaster' }
 
+#CELERY_ACKS_LATE=False
+
+#CELERY_WORKER_CONCURRENCY=1 # set to number of cpu in case of prefork or to higher number in case of gevent pool
+CELERY_WORKER_CONCURRENCY=2
+
+#CELERY_WORKER_PREFETCH_MULTIPLIER=4
 
 # various life times
 

--- a/server/mergin/celery.py
+++ b/server/mergin/celery.py
@@ -66,6 +66,11 @@ def configure_celery(celery: Celery, app: Flask, packages: List[str]):
                 return self.run(*args, **kwargs)
 
     celery.conf.update(app.config)
+    celery.conf.update(
+        task_acks_late=Configuration.CELERY_ACKS_LATE,
+        worker_concurrency=Configuration.CELERY_WORKER_CONCURRENCY,
+        worker_prefetch_multiplier=Configuration.CELERY_WORKER_PREFETCH_MULTIPLIER,
+    )
     # configure celery with flask context https://flask.palletsprojects.com/en/1.1.x/patterns/celery/
     # e.g. for using flask-mail
     celery.Task = ContextTask

--- a/server/mergin/celery.py
+++ b/server/mergin/celery.py
@@ -68,8 +68,8 @@ def configure_celery(celery: Celery, app: Flask, packages: List[str]):
     celery.conf.update(app.config)
     celery.conf.update(
         task_acks_late=Configuration.CELERY_ACKS_LATE,
-        worker_concurrency=Configuration.CELERY_WORKER_CONCURRENCY,
-        worker_prefetch_multiplier=Configuration.CELERY_WORKER_PREFETCH_MULTIPLIER,
+        worker_concurrency=Configuration.CELERYD_CONCURRENCY,
+        worker_prefetch_multiplier=Configuration.CELERYD_PREFETCH_MULTIPLIER,
     )
     # configure celery with flask context https://flask.palletsprojects.com/en/1.1.x/patterns/celery/
     # e.g. for using flask-mail

--- a/server/mergin/config.py
+++ b/server/mergin/config.py
@@ -75,9 +75,9 @@ class Configuration(object):
         "CELERY_RESULT_BACKEND_TRANSPORT_OPTIONS", default="{}", cast=eval
     )
     CELERY_ACKS_LATE = config("CELERY_ACKS_LATE", default=False, cast=bool)
-    CELERY_WORKER_CONCURRENCY = config("CELERY_WORKER_CONCURRENCY", default=1, cast=int)
-    CELERY_WORKER_PREFETCH_MULTIPLIER = config(
-        "CELERY_WORKER_PREFETCH_MULTIPLIER", default=4, cast=int
+    CELERYD_CONCURRENCY = config("CELERYD_CONCURRENCY", default=1, cast=int)
+    CELERYD_PREFETCH_MULTIPLIER = config(
+        "CELERYD_PREFETCH_MULTIPLIER", default=4, cast=int
     )
 
     # deployment URL (e.g. for links generated in emails)

--- a/server/mergin/config.py
+++ b/server/mergin/config.py
@@ -74,6 +74,11 @@ class Configuration(object):
     CELERY_RESULT_BACKEND_TRANSPORT_OPTIONS = config(
         "CELERY_RESULT_BACKEND_TRANSPORT_OPTIONS", default="{}", cast=eval
     )
+    CELERY_ACKS_LATE = config("CELERY_ACKS_LATE", default=False, cast=bool)
+    CELERY_WORKER_CONCURRENCY = config("CELERY_WORKER_CONCURRENCY", default=1, cast=int)
+    CELERY_WORKER_PREFETCH_MULTIPLIER = config(
+        "CELERY_WORKER_PREFETCH_MULTIPLIER", default=4, cast=int
+    )
 
     # deployment URL (e.g. for links generated in emails)
     MERGIN_BASE_URL = config("MERGIN_BASE_URL", default="")


### PR DESCRIPTION
Add more celery variables to config for easier tuning on production. Defaults are set to the way that for most deployments is should be zero change.