### PR TITLE
Fix geodiff working dir

### DIFF
--- a/server/mergin/sync/config.py
+++ b/server/mergin/sync/config.py
@@ -50,5 +50,5 @@ class Configuration(object):
     # working directory for geodiff actions - should be a fast local storage
     GEODIFF_WORKING_DIR = config(
         "GEODIFF_WORKING_DIR",
-        default=os.path.join(LOCAL_PROJECTS, os.pardir, "geodiff_tmp"),
+        default=os.path.join(LOCAL_PROJECTS, "geodiff_tmp"),
     )

--- a/server/mergin/sync/storages/disk.py
+++ b/server/mergin/sync/storages/disk.py
@@ -98,10 +98,9 @@ def move_to_tmp(src, dest=None):
     if not os.path.exists(src):
         return
     dest = dest if dest else str(uuid.uuid4())
-    rel_path = os.path.relpath(
-        src, start=current_app.config["LOCAL_PROJECTS"]
-    )  # take relative path from parent of all project files
-    temp_path = os.path.join(current_app.config["TEMP_DIR"], dest, rel_path)
+    temp_path = os.path.join(
+        current_app.config["TEMP_DIR"], dest, os.path.basename(src)
+    )
     os.renames(src, temp_path)
     return temp_path
 

--- a/server/mergin/tests/test_celery.py
+++ b/server/mergin/tests/test_celery.py
@@ -96,7 +96,7 @@ def test_clean_temp_files(app):
     assert os.path.exists(path)
     # patch modification time of parent dir
     t = datetime.utcnow() - timedelta(days=(app.config["TEMP_EXPIRATION"] + 1))
-    parent_dir = os.path.dirname(os.path.dirname(path))
+    parent_dir = os.path.dirname(path)
     os.utime(parent_dir, (datetime.timestamp(t), datetime.timestamp(t)))
     remove_temp_files()
     assert not os.path.exists(path)


### PR DESCRIPTION
In current deployment with geodiff working dir on separate volume it was not able to do a cleanup as it assumed all files are always in 'LOCAL_PROJECTS' dir and was doing some rel_path magic. We do not need such thing and file cleanup should work for any file wherever located.