### PR TITLE
Add handling for os.renames on different filesystems to avoid OSError

### DIFF
--- a/server/mergin/sync/storages/disk.py
+++ b/server/mergin/sync/storages/disk.py
@@ -107,13 +107,14 @@ def move_to_tmp(src, dest=None):
         # in the case of specific cross-device error [Errno 18] Invalid cross-device link
         # just rename it within the same root with prefix 'delete-me' for easier custom cleanup
         if e.errno == 18:
-            if src.startsiwth(current_app.config["LOCAL_PROJECTS"]):
+            if src.startswith(current_app.config["LOCAL_PROJECTS"]):
                 root = current_app.config["LOCAL_PROJECTS"]
-            elif src.startsiwth(current_app.config["GEODIFF_WORKING_DIR"]):
+            elif src.startswith(current_app.config["GEODIFF_WORKING_DIR"]):
                 root = current_app.config["GEODIFF_WORKING_DIR"]
             else:
                 root = tempfile.gettempdir()
             temp_path = os.path.join(root, "delete-me-" + dest, os.path.basename(src))
+            os.renames(src, temp_path)
         else:
             raise
     return temp_path

--- a/server/mergin/sync/storages/disk.py
+++ b/server/mergin/sync/storages/disk.py
@@ -1,9 +1,9 @@
 # Copyright (C) Lutra Consulting Limited
 #
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
-
 import os
 import io
+import tempfile
 import time
 import uuid
 import logging
@@ -101,7 +101,21 @@ def move_to_tmp(src, dest=None):
     temp_path = os.path.join(
         current_app.config["TEMP_DIR"], dest, os.path.basename(src)
     )
-    os.renames(src, temp_path)
+    try:
+        os.renames(src, temp_path)
+    except OSError as e:
+        # in the case of specific cross-device error [Errno 18] Invalid cross-device link
+        # just rename it within the same root with prefix 'delete-me' for easier custom cleanup
+        if e.errno == 18:
+            if src.startsiwth(current_app.config["LOCAL_PROJECTS"]):
+                root = current_app.config["LOCAL_PROJECTS"]
+            elif src.startsiwth(current_app.config["GEODIFF_WORKING_DIR"]):
+                root = current_app.config["GEODIFF_WORKING_DIR"]
+            else:
+                root = tempfile.gettempdir()
+            temp_path = os.path.join(root, "delete-me-" + dest, os.path.basename(src))
+        else:
+            raise
     return temp_path
 
 


### PR DESCRIPTION
In case GEODIFF _WORKING_DIR, LOCAL_PROJECTS_DIR and TEMP_DIR are not on the same filesystem we need to fallback to other renaming convention - use the same FS and only add a marker `delete-me`.

Normally this should not happen, but for certain deployments on k8s it may be beneficial to have various volumes of different types mounted. In that case a custom clean up job is necessary - this needs to be DOCUMENTED properly!