### PR TITLE
Fix docker compose to make it running with older docker images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     user: 901:999
     volumes:
       - ./projects:/data
+      - ./server/entrypoint.sh:/app/entrypoint.sh
     env_file:
       - .prod.env
     depends_on:
@@ -38,8 +39,11 @@ services:
   celery-beat:
     image: lutraconsulting/merginmaps-backend:2024.2.2
     container_name: celery-beat
+    restart: always
     env_file:
       - .prod.env
+    volumes:
+      - ./server/entrypoint.sh:/app/entrypoint.sh
     depends_on:
       - redis
       - server-gunicorn
@@ -49,8 +53,13 @@ services:
   celery-worker:
     image: lutraconsulting/merginmaps-backend:2024.2.2
     container_name: celery-worker
+    restart: always
+    user: 901:999
     env_file:
       - .prod.env
+    volumes:
+      - ./projects:/data
+      - ./server/entrypoint.sh:/app/entrypoint.sh
     depends_on:
       - redis
       - server-gunicorn


### PR DESCRIPTION
After split of celery-* and server containers running docker-compose.yml with CE/EE older images results in confusing situation, e.g. running services multiple times or not running them all. This is because we changed entrypoint.sh to accept any runtime command from docker-compose file which is not respected by older images.

To overcome this limitation new entrypoint.sh is mounted to replace the one built in images.
Also missing keys were added for celery containers in compose file.

Logs:
```
merginmaps-server  | [INFO] [7] Starting gunicorn 19.9.0
merginmaps-server  | [INFO] [7] Listening at: http://0.0.0.0:5000 (7)
merginmaps-server  | [INFO] [7] Using worker: gevent
merginmaps-server  | [INFO] [9] Booting worker with pid: 9
merginmaps-server  | [INFO] [10] Booting worker with pid: 10
celery-beat        | [2024-10-25 13:41:48,935: INFO/MainProcess] beat: Starting...
celery-worker      | [2024-10-25 13:41:49,133: INFO/MainProcess] Connected to redis://merginmaps-redis:6379/0
celery-worker      | [2024-10-25 13:41:49,142: INFO/MainProcess] mingle: searching for neighbors
celery-worker      | [2024-10-25 13:41:50,155: INFO/MainProcess] mingle: all alone
celery-worker      | [2024-10-25 13:41:50,185: INFO/MainProcess] celery@74aa5e3990ab ready.
```