### PR TITLE
Flush to DB right after project is created

### DIFF
--- a/server/mergin/sync/models.py
+++ b/server/mergin/sync/models.py
@@ -24,7 +24,6 @@ from flask import current_app
 
 from .files import (
     File,
-    UploadFile,
     UploadChanges,
     ChangesSchema,
     ProjectFile,

--- a/server/mergin/sync/public_api_controller.py
+++ b/server/mergin/sync/public_api_controller.py
@@ -193,6 +193,7 @@ def add_project(namespace):  # noqa: E501
 
         p = Project(**request.json, creator=current_user, workspace=workspace)
         p.updated = datetime.utcnow()
+        db.session.add(p)
         db.session.flush()
         pa = ProjectAccess(p, public=request.json.get("public", False))
 
@@ -229,7 +230,6 @@ def add_project(namespace):  # noqa: E501
             get_device_id(request),
         )
 
-        db.session.add(p)
         db.session.add(pa)
         db.session.add(version)
         db.session.commit()
@@ -1182,6 +1182,7 @@ def clone_project(namespace, project_name):  # noqa: E501
         workspace=ws,
     )
     p.updated = datetime.utcnow()
+    db.session.add(p)
     pa = ProjectAccess(p, public=False)
 
     try:
@@ -1207,7 +1208,6 @@ def clone_project(namespace, project_name):  # noqa: E501
         user_agent,
         device_id,
     )
-    db.session.add(p)
     db.session.add(pa)
     db.session.add(project_version)
     db.session.commit()

--- a/server/mergin/sync/public_api_controller.py
+++ b/server/mergin/sync/public_api_controller.py
@@ -193,6 +193,7 @@ def add_project(namespace):  # noqa: E501
 
         p = Project(**request.json, creator=current_user, workspace=workspace)
         p.updated = datetime.utcnow()
+        db.session.flush()
         pa = ProjectAccess(p, public=request.json.get("public", False))
 
         template_name = request.json.get("template", None)

--- a/server/mergin/sync/public_api_controller.py
+++ b/server/mergin/sync/public_api_controller.py
@@ -194,7 +194,6 @@ def add_project(namespace):  # noqa: E501
         p = Project(**request.json, creator=current_user, workspace=workspace)
         p.updated = datetime.utcnow()
         db.session.add(p)
-        db.session.flush()
         pa = ProjectAccess(p, public=request.json.get("public", False))
 
         template_name = request.json.get("template", None)

--- a/server/mergin/tests/test_project_controller.py
+++ b/server/mergin/tests/test_project_controller.py
@@ -37,7 +37,7 @@ from ..sync.models import (
     ProjectFilePath,
 )
 from ..sync.files import ChangesSchema
-from ..sync.schemas import ProjectListSchema, ProjectSchema
+from ..sync.schemas import ProjectListSchema
 from ..sync.utils import generate_checksum, is_versioned_file
 from ..auth.models import User, UserProfile
 

--- a/server/mergin/tests/utils.py
+++ b/server/mergin/tests/utils.py
@@ -78,7 +78,7 @@ def create_project(name, workspace, user, **kwargs):
 
     p = Project(**project_params, **kwargs)
     p.updated = datetime.utcnow()
-    db.session.add(p)
+    db.session.flush()
 
     public = kwargs.get("public", False)
     pa = ProjectAccess(p, public)


### PR DESCRIPTION
Let's fix the tests. 

We need project object attributes and relations to be accessible right after it is created because when ProjectVersion is created is sends signal which expects it.