### PR TITLE
Update statistics counts + editors

### DIFF
--- a/server/mergin/auth/api.yaml
+++ b/server/mergin/auth/api.yaml
@@ -924,7 +924,7 @@ components:
       type: object
       properties:
         active_monthly_contributors:
-          type: array
+          type: integer
           description: count of users who made a project change last months
           items:
             type: integer

--- a/server/mergin/auth/controller.py
+++ b/server/mergin/auth/controller.py
@@ -549,8 +549,9 @@ def get_server_usage():
         "projects": Project.query.filter(Project.removed_at.is_(None)).count(),
         "storage": files_size(),
         "users": User.query.filter(
-            is_(User.username.ilike("deleted_%"), False) | is_(User.active, True)
+            is_(User.username.ilike("deleted_%"), False) | User.active,
         ).count(),
         "workspaces": current_app.ws_handler.workspace_count(),
+        "editors": current_app.ws_handler.server_editors_count(),
     }
     return data, 200

--- a/server/mergin/auth/controller.py
+++ b/server/mergin/auth/controller.py
@@ -545,15 +545,12 @@ def create_user():
 @auth_required(permissions=["admin"])
 def get_server_usage():
     data = {
-        "active_monthly_contributors": [
-            current_app.ws_handler.monthly_contributors_count(),
-            current_app.ws_handler.monthly_contributors_count(month_offset=1),
-            current_app.ws_handler.monthly_contributors_count(month_offset=2),
-            current_app.ws_handler.monthly_contributors_count(month_offset=3),
-        ],
-        "projects": Project.query.count(),
+        "active_monthly_contributors": current_app.ws_handler.monthly_contributors_count(),
+        "projects": Project.query.filter(Project.removed_at.is_(None)).count(),
         "storage": files_size(),
-        "users": User.query.count(),
+        "users": User.query.filter(
+            is_(User.username.ilike("deleted_%"), False) | is_(User.active, True)
+        ).count(),
         "workspaces": current_app.ws_handler.workspace_count(),
     }
     return data, 200

--- a/server/mergin/stats/tasks.py
+++ b/server/mergin/stats/tasks.py
@@ -7,6 +7,7 @@ import datetime
 import json
 import logging
 from flask import current_app
+from sqlalchemy.sql.operators import is_
 
 from .models import MerginInfo
 from ..celery import celery
@@ -60,8 +61,10 @@ def send_statistics():
         "url": current_app.config["MERGIN_BASE_URL"],
         "contact_email": current_app.config["CONTACT_EMAIL"],
         "licence": current_app.config["SERVER_TYPE"],
-        "projects_count": Project.query.count(),
-        "users_count": User.query.count(),
+        "projects_count": Project.query.filter(Project.removed_at.is_(None)).count(),
+        "users_count": User.query.filter(
+            is_(User.username.ilike("deleted_%"), False) | is_(User.active, True)
+        ).count(),
         "workspaces_count": current_app.ws_handler.workspace_count(),
         "last_change": str(last_change_item.updated) + "Z" if last_change_item else "",
         "server_version": current_app.config["VERSION"],

--- a/server/mergin/stats/tasks.py
+++ b/server/mergin/stats/tasks.py
@@ -69,6 +69,7 @@ def send_statistics():
         "last_change": str(last_change_item.updated) + "Z" if last_change_item else "",
         "server_version": current_app.config["VERSION"],
         "monthly_contributors": current_app.ws_handler.monthly_contributors_count(),
+        "editors": current_app.ws_handler.server_editors_count(),
     }
 
     try:

--- a/server/mergin/sync/interfaces.py
+++ b/server/mergin/sync/interfaces.py
@@ -172,6 +172,13 @@ class WorkspaceHandler(ABC):
         """
         pass
 
+    @staticmethod
+    def server_editors_count():
+        """
+        Return number of workspace editors in current server instance
+        """
+        pass
+
 
 class AbstractProjectHandler(ABC):
     @abstractmethod

--- a/server/mergin/sync/workspace.py
+++ b/server/mergin/sync/workspace.py
@@ -6,12 +6,14 @@ from datetime import datetime, timedelta, timezone
 from typing import Dict, Tuple, Optional, Set, List
 from flask_login import current_user
 from sqlalchemy import Column, literal, extract
+from sqlalchemy.sql.operators import is_
 
 from .errors import UpdateProjectAccessError
 from .models import (
     Project,
     AccessRequest,
     ProjectAccessDetail,
+    ProjectRole,
     ProjectVersion,
     ProjectUser,
 )
@@ -349,3 +351,26 @@ class GlobalWorkspaceHandler(WorkspaceHandler):
                 )
                 result.append(member)
         return result
+
+    def server_editors_count(self) -> int:
+        if Configuration.GLOBAL_ADMIN or Configuration.GLOBAL_WRITE:
+            return User.query.filter(
+                is_(User.username.ilike("deleted_%"), False) | User.active
+            ).count()
+        if Configuration.GLOBAL_READ:
+            return User.query.filter(
+                is_(User.username.ilike("deleted_%"), False) | User.active,
+                User.is_admin.is_(True),
+            ).count()
+
+        return (
+            db.session.query(ProjectUser.user_id)
+            .select_from(Project)
+            .join(ProjectUser)
+            .filter(
+                Project.removed_at.is_(None),
+                ProjectUser.role != ProjectRole.READER.value,
+            )
+            .group_by(ProjectUser.user_id)
+            .count()
+        )

--- a/server/mergin/tests/test_auth.py
+++ b/server/mergin/tests/test_auth.py
@@ -858,6 +858,7 @@ def test_server_usage(client):
     # create new project
     project = create_project("project", workspace, admin)
     project.set_role(user.id, ProjectRole.READER)
+    db.session.commit()
     upload_file_to_project(project, "test.txt", client)
     resp = client.get("/app/admin/usage")
     assert resp.status_code == 200
@@ -866,3 +867,8 @@ def test_server_usage(client):
     assert resp.json["projects"] == 2
     assert resp.json["storage"] == "454 kB"
     assert resp.json["active_monthly_contributors"] == 1
+    assert resp.json["editors"] == 1
+    project.set_role(user.id, ProjectRole.EDITOR)
+    db.session.commit()
+    resp = client.get("/app/admin/usage")
+    assert resp.json["editors"] == 2

--- a/server/mergin/tests/test_statistics.py
+++ b/server/mergin/tests/test_statistics.py
@@ -54,6 +54,8 @@ def test_send_statistics(app, caplog):
         assert data["service_uuid"] == app.config["SERVICE_ID"]
         assert data["licence"] == "ce"
         assert data["monthly_contributors"] == 1
+        assert data["users_count"] == 1
+        assert data["projects_count"] == 1
         assert data["contact_email"] == "test@example.com"
 
         # repeated action does not do anything

--- a/server/mergin/tests/test_statistics.py
+++ b/server/mergin/tests/test_statistics.py
@@ -49,6 +49,7 @@ def test_send_statistics(app, caplog):
             "last_change",
             "server_version",
             "monthly_contributors",
+            "editors",
         }
         assert data["workspaces_count"] == 1
         assert data["service_uuid"] == app.config["SERVICE_ID"]
@@ -57,6 +58,7 @@ def test_send_statistics(app, caplog):
         assert data["users_count"] == 1
         assert data["projects_count"] == 1
         assert data["contact_email"] == "test@example.com"
+        assert data["editors"] == 1
 
         # repeated action does not do anything
         task = send_statistics.s().apply()

--- a/server/mergin/tests/test_workspace.py
+++ b/server/mergin/tests/test_workspace.py
@@ -36,10 +36,16 @@ def test_workspace_implementation(client):
     assert handler.list_active()[0].name == ws.name
     assert len(handler.list_user_workspaces(user.username)) == 1
     assert handler.list_user_workspaces(user.username)[0].name == ws.name
+    Configuration.GLOBAL_READ = True
+    assert ws.user_has_permissions(user, "read")
+    assert not ws.user_has_permissions(user, "write")
+    # admin is counted as editor
+    assert handler.server_editors_count() == 1
     # change global flag to enable user push to any project
     Configuration.GLOBAL_WRITE = True
     assert ws.user_has_permissions(user, "write")
     assert ws.user_has_permissions(user, "read")
+    assert handler.server_editors_count() == 2
     assert not ws.user_has_permissions(user, "admin")
     assert not ws.user_has_permissions(user, "owner")
 
@@ -70,6 +76,7 @@ def test_workspace_implementation(client):
     project.removed_by = user.id
     db.session.commit()
     assert ws.disk_usage() == default_project_usage
+    assert handler.server_editors_count() == 2
 
     current_time = datetime.datetime.now(datetime.timezone.utc)
     latest_version.created = datetime.datetime.combine(

--- a/web-app/packages/admin-lib/src/modules/admin/store.ts
+++ b/web-app/packages/admin-lib/src/modules/admin/store.ts
@@ -42,6 +42,7 @@ export interface AdminState {
   checkForUpdates?: boolean
   isServerConfigHidden: boolean
   latestServerVersion?: LatestServerVersionResponse
+  usage: ServerUsageResponse
 }
 
 const cookies = new Cookies()
@@ -62,7 +63,8 @@ export const useAdminStore = defineStore('adminModule', {
     user: null,
     checkForUpdates: undefined,
     isServerConfigHidden: false,
-    latestServerVersion: undefined
+    latestServerVersion: undefined,
+    usage: undefined
   }),
   getters: {
     displayUpdateAvailable: (state) => {
@@ -111,9 +113,6 @@ export const useAdminStore = defineStore('adminModule', {
     },
     setIsServerConfigHidden(value: boolean) {
       this.isServerConfigHidden = value
-    },
-    setUsage(data: ServerUsageResponse){
-      this.usage = data
     },
 
     async fetchUsers(payload: { params: PaginatedUsersParams }) {
@@ -322,7 +321,7 @@ export const useAdminStore = defineStore('adminModule', {
       const notificationStore = useNotificationStore()
       try {
         const response = await AdminApi.getServerUsage()
-        this.setUsage(response.data)
+        this.usage = response.data
       } catch (e) {
         notificationStore.error({ text: errorUtils.getErrorMessage(e) })
       }

--- a/web-app/packages/admin-lib/src/modules/admin/types.ts
+++ b/web-app/packages/admin-lib/src/modules/admin/types.ts
@@ -72,7 +72,7 @@ export interface PaginatedAdminProjectsParams extends PaginatedRequestParams {
 export type ServerUsageResponse = ServerUsage
 
 export interface ServerUsage {
-  active_monthly_contributors: number[]
+  active_monthly_contributors: number
   projects: number
   storage: string
   users: number

--- a/web-app/packages/admin-lib/src/modules/admin/types.ts
+++ b/web-app/packages/admin-lib/src/modules/admin/types.ts
@@ -77,6 +77,7 @@ export interface ServerUsage {
   storage: string
   users: number
   workspaces: number
+  editors: number
 }
 
 /* eslint-enable camelcase */

--- a/web-app/packages/admin-lib/src/modules/admin/views/OverviewView.vue
+++ b/web-app/packages/admin-lib/src/modules/admin/views/OverviewView.vue
@@ -15,7 +15,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
     <app-container>
       <div class="grid" v-if="usage">
         <usage-card class="col-12 sm:col-6 lg:col-3">
-          <template #heading>Active monthly contributors</template>
+          <template #heading>Editors</template>
           <div
             class="w-full"
             :style="{
@@ -25,19 +25,10 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             <PProgressBar :value="0" :show-value="false"></PProgressBar>
           </div>
           <template #title
-            ><span>{{ usage?.active_monthly_contributors }}</span></template
+            ><span>{{ usage?.editors }}</span></template
           >
-          <template #subtitle>this month</template>
-          <template #footer>
-            <!--            TODO: click to see last three month graph-->
-            <!--              <PButton-->
-            <!--                @click=""-->
-            <!--                class="w-full"-->
-            <!--                label="See more"-->
-            <!--              />-->
-          </template>
         </usage-card>
-        <usage-card v-if="usage?.storage" class="col-12 sm:col-6 lg:col-3">
+        <usage-card class="col-12 sm:col-6 lg:col-3">
           <template #heading>Used storage</template>
           <div
             class="w-full"
@@ -51,7 +42,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             ><span>{{ usage?.storage }}</span></template
           >
         </usage-card>
-        <usage-card v-if="usage?.users" class="col-12 sm:col-6 lg:col-3">
+        <usage-card class="col-12 sm:col-6 lg:col-3">
           <template #heading>Registered accounts</template>
           <div
             class="w-full"
@@ -72,7 +63,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             />
           </template>
         </usage-card>
-        <usage-card v-if="usage?.projects" class="col-12 sm:col-6 lg:col-3">
+        <usage-card class="col-12 sm:col-6 lg:col-3">
           <template #heading>Projects</template>
           <div
             class="w-full"
@@ -91,6 +82,29 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
               class="w-full"
               label="Manage projects"
             />
+          </template>
+        </usage-card>
+        <usage-card class="col-12 sm:col-6 lg:col-3">
+          <template #heading>Active monthly contributors</template>
+          <div
+            class="w-full"
+            :style="{
+              height: '40px'
+            }"
+          >
+            <PProgressBar :value="0" :show-value="false"></PProgressBar>
+          </div>
+          <template #title
+            ><span>{{ usage?.active_monthly_contributors }}</span></template
+          >
+          <template #subtitle>this month</template>
+          <template #footer>
+            <!--            TODO: click to see last three month graph-->
+            <!--              <PButton-->
+            <!--                @click=""-->
+            <!--                class="w-full"-->
+            <!--                label="See more"-->
+            <!--              />-->
           </template>
         </usage-card>
         <usage-card v-if="showWorkspaces" class="col-12 sm:col-6 lg:col-3">

--- a/web-app/packages/admin-lib/src/modules/admin/views/OverviewView.vue
+++ b/web-app/packages/admin-lib/src/modules/admin/views/OverviewView.vue
@@ -14,10 +14,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 
     <app-container>
       <div class="grid" v-if="usage">
-        <usage-card
-          v-if="usage?.active_monthly_contributors"
-          class="col-12 sm:col-6 lg:col-3"
-        >
+        <usage-card class="col-12 sm:col-6 lg:col-3">
           <template #heading>Active monthly contributors</template>
           <div
             class="w-full"
@@ -28,9 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             <PProgressBar :value="0" :show-value="false"></PProgressBar>
           </div>
           <template #title
-            ><span>{{
-              this.usage?.active_monthly_contributors[0]
-            }}</span></template
+            ><span>{{ usage?.active_monthly_contributors }}</span></template
           >
           <template #subtitle>this month</template>
           <template #footer>
@@ -53,7 +48,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             <PProgressBar :value="0" :show-value="false"></PProgressBar>
           </div>
           <template #title
-            ><span>{{ this.usage?.storage }}</span></template
+            ><span>{{ usage?.storage }}</span></template
           >
         </usage-card>
         <usage-card v-if="usage?.users" class="col-12 sm:col-6 lg:col-3">
@@ -67,7 +62,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             <PProgressBar :value="0" :show-value="false"></PProgressBar>
           </div>
           <template #title
-            ><span>{{ this.usage?.users }}</span></template
+            ><span>{{ usage?.users }}</span></template
           >
           <template #footer>
             <PButton
@@ -88,13 +83,13 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             <PProgressBar :value="0" :show-value="false"></PProgressBar>
           </div>
           <template #title
-            ><span>{{ this.usage?.projects }}</span></template
+            ><span>{{ usage?.projects }}</span></template
           >
           <template #footer>
             <PButton
               @click="$router.push({ name: AdminRoutes.PROJECTS })"
               class="w-full"
-              label="Manage users"
+              label="Manage projects"
             />
           </template>
         </usage-card>
@@ -109,7 +104,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             <PProgressBar :value="0" :show-value="false"></PProgressBar>
           </div>
           <template #title
-            ><span>{{ this.usage?.workspaces }}</span></template
+            ><span>{{ usage?.workspaces }}</span></template
           >
           <template #footer>
             <PButton
@@ -147,7 +142,7 @@ export default defineComponent({
     }
   },
   methods: {
-    getUsage(): any {
+    getUsage(): void {
       const adminStore = useAdminStore()
       adminStore.getServerUsage()
     }


### PR DESCRIPTION
CE Resolves https://github.com/MerginMaps/server-private/issues/2670

Fix :hammer: 
- updates to OverviewView
- send just active non-removed projects nd users to stats

Added :heavy_plus_sign: 
- added editors count to stats and server usage for admin
- add new card with editors count to admin overview
![image](https://github.com/user-attachments/assets/f38a1821-caae-460a-9411-75080b7759b8)
