### PR TITLE
Use v2 update project access

### DIFF
--- a/server/mergin/sync/models.py
+++ b/server/mergin/sync/models.py
@@ -360,6 +360,7 @@ class ProjectAccessDetail:
     username: str
     name: Optional[str]
     project_permission: str
+    project_role: Optional[ProjectRole]
     type: str
 
 

--- a/server/mergin/sync/private_api.yaml
+++ b/server/mergin/sync/private_api.yaml
@@ -594,6 +594,14 @@ components:
             - writer
             - editor
             - reader
+        project_role:
+          type: string
+          nullable: true
+          enum:
+            - owner
+            - writer
+            - editor
+            - reader
         invitation:
           description: Present only for type `invitation`
           type: object

--- a/server/mergin/sync/schemas.py
+++ b/server/mergin/sync/schemas.py
@@ -362,6 +362,7 @@ class ProjectAccessDetailSchema(Schema):
     username = fields.String()
     name = fields.String()
     project_permission = fields.String()
+    project_role = fields.String()
     type = fields.String()
     invitation = fields.Nested(ProjectInvitationAccessSchema())
 

--- a/web-app/packages/admin-lib/src/modules/admin/views/AccountDetailView.vue
+++ b/web-app/packages/admin-lib/src/modules/admin/views/AccountDetailView.vue
@@ -215,7 +215,8 @@ const changeStatusDialog = () => {
       await adminStore.updateUser({
         username: user.value.username,
         data: {
-          active: !user.value.active
+          active: !user.value.active,
+          is_admin: user.value.is_admin
         }
       })
     }

--- a/web-app/packages/lib/src/common/permission_utils.ts
+++ b/web-app/packages/lib/src/common/permission_utils.ts
@@ -16,7 +16,6 @@ export enum WorkspaceRole {
 }
 
 export enum ProjectRole {
-  none,
   reader,
   editor,
   writer,
@@ -37,9 +36,10 @@ export type WorkspaceRoleName =
   | 'admin'
   | 'owner'
 
-export type ProjectRoleName =
-  | Extract<WorkspaceRoleName, 'reader' | 'editor' | 'writer' | 'owner'>
-  | 'none'
+export type ProjectRoleName = Extract<
+  WorkspaceRoleName,
+  'reader' | 'editor' | 'writer' | 'owner'
+>
 
 export type ProjectPermissionName = 'owner' | 'write' | 'edit' | 'read'
 
@@ -63,7 +63,6 @@ export const USER_ROLE_BY_NAME: Record<WorkspaceRoleName, WorkspaceRole> = {
 }
 
 export const PROJECT_ROLE_NAME_BY_ROLE: Record<ProjectRole, ProjectRoleName> = {
-  [ProjectRole.none]: 'none',
   [ProjectRole.reader]: 'reader',
   [ProjectRole.editor]: 'editor',
   [ProjectRole.writer]: 'writer',
@@ -71,7 +70,6 @@ export const PROJECT_ROLE_NAME_BY_ROLE: Record<ProjectRole, ProjectRoleName> = {
 }
 
 export const PROJECT_ROLE_BY_NAME: Record<ProjectRoleName, ProjectRole> = {
-  none: ProjectRole.none,
   reader: ProjectRole.reader,
   editor: ProjectRole.editor,
   writer: ProjectRole.writer,
@@ -191,8 +189,7 @@ export function getProjectAccessKeyByRoleName(
     owner: 'ownersnames',
     writer: 'writersnames',
     editor: 'editorsnames',
-    reader: 'readersnames',
-    none: undefined
+    reader: 'readersnames'
   }
   return mapper[roleName]
 }
@@ -200,12 +197,11 @@ export function getProjectAccessKeyByRoleName(
 export function getProjectPermissionByRoleName(
   roleName: ProjectRoleName
 ): ProjectPermissionName {
-  const mapper: Record<ProjectRoleName, ProjectPermissionName | undefined> = {
+  const mapper: Record<ProjectRoleName, ProjectPermissionName> = {
     owner: 'owner',
     writer: 'write',
     editor: 'edit',
-    reader: 'read',
-    none: undefined
+    reader: 'read'
   }
   return mapper[roleName]
 }

--- a/web-app/packages/lib/src/modules/project/components/AccessRequestTableTemplate.vue
+++ b/web-app/packages/lib/src/modules/project/components/AccessRequestTableTemplate.vue
@@ -187,7 +187,7 @@ export default defineComponent({
         await this.acceptProjectAccessRequest({
           data,
           itemId: request.id,
-          namespace: this.namespace
+          workspace: this.namespace
         })
         await this.updatePaginationOrFetch()
       } catch (err) {
@@ -200,7 +200,7 @@ export default defineComponent({
     async cancelRequest(request) {
       await this.cancelProjectAccessRequest({
         itemId: request.id,
-        namespace: this.namespace
+        workspace: this.namespace
       })
       await this.updatePaginationOrFetch()
     },

--- a/web-app/packages/lib/src/modules/project/components/ProjectAccessRequests.vue
+++ b/web-app/packages/lib/src/modules/project/components/ProjectAccessRequests.vue
@@ -158,7 +158,7 @@ export default defineComponent({
         await this.acceptProjectAccessRequest({
           data,
           itemId: request.id,
-          namespace: this.project.namespace
+          workspace: this.project.namespace
         })
         await this.updatePaginationOrFetch()
       } catch (err) {
@@ -173,7 +173,7 @@ export default defineComponent({
     async cancelRequest(request) {
       await this.cancelProjectAccessRequest({
         itemId: request.id,
-        namespace: this.project.namespace
+        workspace: this.project.namespace
       })
       await this.updatePaginationOrFetch()
     },

--- a/web-app/packages/lib/src/modules/project/components/ProjectMembersTable.vue
+++ b/web-app/packages/lib/src/modules/project/components/ProjectMembersTable.vue
@@ -163,7 +163,7 @@ function removeMember(item: ProjectAccessDetail) {
 function roleUpdate(item: ProjectAccessDetail, value: ProjectRoleName) {
   projectStore.updateProjectAccess({
     projectId: projectStore.project.id,
-    userId: item.id,
+    access: item,
     data: { role: value }
   })
 }

--- a/web-app/packages/lib/src/modules/project/components/ProjectsTableDataLoader.vue
+++ b/web-app/packages/lib/src/modules/project/components/ProjectsTableDataLoader.vue
@@ -60,10 +60,6 @@ export default defineComponent({
       default: false
     },
     namespace: String,
-    asAdmin: {
-      type: Boolean,
-      default: false
-    },
     public: {
       type: Boolean,
       default: true
@@ -135,9 +131,6 @@ export default defineComponent({
       }
       if (projectGridState.namespace) {
         params.only_namespace = projectGridState.namespace
-      }
-      if (this.asAdmin) {
-        params.as_admin = true
       }
       if (!this.public) {
         params.public = false

--- a/web-app/packages/lib/src/modules/project/projectApi.ts
+++ b/web-app/packages/lib/src/modules/project/projectApi.ts
@@ -184,7 +184,8 @@ export const ProjectApi = {
       `/v2/projects/${id}/collaborators/${userId}`,
       data,
       {
-        ...(withRetry ? getDefaultRetryOptions() : {})
+        ...(withRetry ? getDefaultRetryOptions() : {}),
+        validateStatus
       }
     )
   },
@@ -207,7 +208,8 @@ export const ProjectApi = {
     return ProjectModule.httpService.delete(
       `/v2/projects/${id}/collaborators/${userId}`,
       {
-        ...(withRetry ? getDefaultRetryOptions() : {})
+        ...(withRetry ? getDefaultRetryOptions() : {}),
+        validateStatus
       }
     )
   },

--- a/web-app/packages/lib/src/modules/project/projectApi.ts
+++ b/web-app/packages/lib/src/modules/project/projectApi.ts
@@ -25,8 +25,10 @@ import {
   ProjectAccessDetail,
   ProjectAccess,
   ProjectVersionFileChange,
-  UpdateProjectPayload,
-  UpdatePublicFlagParams
+  UpdateProjectCollaboratorPayload,
+  UpdatePublicFlagParams,
+  ProjectCollaborator,
+  AddProjectCollaboratorPayload
 } from '@/modules/project/types'
 
 export const ProjectApi = {
@@ -174,17 +176,28 @@ export const ProjectApi = {
     )
   },
 
-  async updateProjectAccess(
+  async addProjectCollaborator(
+    id: string,
+    data: AddProjectCollaboratorPayload
+  ): Promise<AxiosResponse<ProjectCollaborator>> {
+    return ProjectModule.httpService.post(
+      `/v2/projects/${id}/collaborators`,
+      data,
+      {
+        validateStatus
+      }
+    )
+  },
+
+  async updateProjectCollaborator(
     id: string,
     userId: number,
-    data: UpdateProjectPayload,
-    withRetry?: boolean
-  ): Promise<AxiosResponse<ProjectAccess>> {
+    data: UpdateProjectCollaboratorPayload
+  ): Promise<AxiosResponse<ProjectCollaborator>> {
     return ProjectModule.httpService.patch(
       `/v2/projects/${id}/collaborators/${userId}`,
       data,
       {
-        ...(withRetry ? getDefaultRetryOptions() : {}),
         validateStatus
       }
     )
@@ -200,15 +213,13 @@ export const ProjectApi = {
     })
   },
 
-  async removeProjectAccess(
+  async removeProjectCollaborator(
     id: string,
-    userId: number,
-    withRetry?: boolean
-  ): Promise<AxiosResponse<ProjectAccess>> {
+    userId: number
+  ): Promise<AxiosResponse<void>> {
     return ProjectModule.httpService.delete(
       `/v2/projects/${id}/collaborators/${userId}`,
       {
-        ...(withRetry ? getDefaultRetryOptions() : {}),
         validateStatus
       }
     )

--- a/web-app/packages/lib/src/modules/project/store.ts
+++ b/web-app/packages/lib/src/modules/project/store.ts
@@ -41,7 +41,6 @@ import {
   SaveProjectSettings,
   ErrorCodes,
   ProjectAccessDetail,
-  UpdateProjectAccessParams,
   ProjectVersionFileChange,
   ProjectVersionListItem,
   UpdateProjectPayload,
@@ -757,8 +756,8 @@ export const useProjectStore = defineStore('projectModule', {
     async removeProjectAccess(
       item: Pick<ProjectAccessDetail, 'id' | 'username'>
     ) {
-      const notificationStore = useNotificationStore()
       this.accessLoading = true
+      const notificationStore = useNotificationStore()
       try {
         const response = await ProjectApi.removeProjectAccess(
           this.project.id,
@@ -786,7 +785,6 @@ export const useProjectStore = defineStore('projectModule', {
       userId: number
       data: UpdateProjectPayload
     }) {
-      const notificationStore = useNotificationStore()
       this.accessLoading = true
       try {
         const response = await ProjectApi.updateProjectAccess(
@@ -801,13 +799,18 @@ export const useProjectStore = defineStore('projectModule', {
           return access
         })
         this.project.access = response.data
-      } catch {
-        notificationStore.error({
-          text: `Failed to update project access`
-        })
+      } catch (err) {
+        this.handleProjectAccessError(err, 'Failed to update project access')
       } finally {
         this.accessLoading = false
       }
+    },
+
+    handleProjectAccessError(err: unknown, defaultMessage: string) {
+      const notificationStore = useNotificationStore()
+      notificationStore.error({
+        text: getErrorMessage(err, defaultMessage)
+      })
     },
 
     async updatePublicFlag(payload: {

--- a/web-app/packages/lib/src/modules/project/types.ts
+++ b/web-app/packages/lib/src/modules/project/types.ts
@@ -5,7 +5,8 @@
 /* eslint-disable camelcase */
 import {
   ProjectRoleName,
-  ProjectPermissionName
+  ProjectPermissionName,
+  WorkspaceRoleName
 } from '@/common/permission_utils'
 import {
   PaginatedRequestParamsApi,
@@ -184,12 +185,12 @@ export interface GetAccessRequestsPayload extends GetUserAccessRequestsPayload {
 export interface AcceptProjectAccessRequestPayload {
   itemId: number
   data: AcceptProjectAccessRequestData
-  namespace?: string
+  workspace?: string
 }
 
 export interface CancelProjectAccessRequestPayload {
   itemId: number
-  namespace: string
+  workspace: string
 }
 
 export interface CreateProjectParams {
@@ -292,7 +293,12 @@ export type EnhancedProjectDetail = ProjectDetail & {
   path: string
 }
 
-export interface UpdateProjectPayload {
+export interface AddProjectCollaboratorPayload {
+  role: ProjectRoleName
+  username: string
+}
+
+export interface UpdateProjectCollaboratorPayload {
   role: ProjectRoleName
 }
 
@@ -341,11 +347,30 @@ export interface ProjectVersionFileChange {
 
 export type ErrorCodes = 'UpdateProjectAccessError'
 
+export type ProjectAccessDetailType = 'invitation' | 'member'
+
 export interface ProjectAccessDetail {
-  id: number
-  type: 'member'
+  id: number | string
+  type: ProjectAccessDetailType
+  role: WorkspaceRoleName
+  name?: string
   email: string
-  username: string
-  project_permission: ProjectRoleName
-  name: string
+  username?: string
+  project_permission?: ProjectRoleName
+  project_role?: ProjectRoleName | null
+  invitation?: {
+    expires_at: string
+    projects?: {
+      ids: string[]
+      permissions: ProjectPermissionName
+    }
+  }
+}
+
+export interface ProjectCollaborator {
+  id: number
+  usernaname: string
+  email: string
+  workspace_role: WorkspaceRoleName
+  project_role: ProjectRoleName
 }


### PR DESCRIPTION
Resolves https://github.com/MerginMaps/server-private/issues/2672
Partially resolves https://github.com/MerginMaps/server-private/issues/2686

Cleanup :boom: 
- 'none' ProjectRole , not sure if there is use case for it (in PUT v1/access ? @varmar05 

Added :heavy_plus_sign: 
- Added project_role attribute to private endpoint for /access as we can use it for checking if there is any 
- added error handling methods for some endpoints used to limits with pinia plugin

Updated :hammer: 
- rename and introduce ProjectCollaborators methods handling in api and project store
