### PR TITLE
Remove default detail message from 404 in collaborators

### DIFF
--- a/server/mergin/sync/public_api_v2_controller.py
+++ b/server/mergin/sync/public_api_v2_controller.py
@@ -113,7 +113,7 @@ def update_project_collaborator(id, user_id):
     project = require_project_by_uuid(id, ProjectPermissions.Update)
     user = User.query.filter_by(id=user_id, active=True).first_or_404()
     if not project.get_role(user_id):
-        abort(404, "User is not a project member")
+        abort(404)
 
     project.set_role(user.id, ProjectRole(request.json["role"]))
     db.session.commit()
@@ -126,7 +126,7 @@ def remove_project_collaborator(id, user_id):
     """Remove project collaborator"""
     project = require_project_by_uuid(id, ProjectPermissions.Update)
     if not project.get_role(user_id):
-        abort(404, "User is not a project member")
+        abort(404)
 
     project.unset_role(user_id)
     db.session.commit()


### PR DESCRIPTION
Fixes https://github.com/MerginMaps/server-private/issues/2711

Unify 404 error message for users which are not found.