### PR TITLE
Fix: Deactivate account in admin

### DIFF
--- a/web-app/packages/admin-lib/src/modules/admin/types.ts
+++ b/web-app/packages/admin-lib/src/modules/admin/types.ts
@@ -19,8 +19,8 @@ export interface UsersParams extends PaginatedRequestParams {
 export type UsersResponse = PaginatedResponse<UserResponse>
 
 export interface UpdateUserData {
-  is_admin: boolean
-  active: boolean
+  is_admin?: boolean
+  active?: boolean
 }
 
 export interface CreateUserData {

--- a/web-app/packages/admin-lib/src/modules/admin/views/AccountDetailView.vue
+++ b/web-app/packages/admin-lib/src/modules/admin/views/AccountDetailView.vue
@@ -215,8 +215,7 @@ const changeStatusDialog = () => {
       await adminStore.updateUser({
         username: user.value.username,
         data: {
-          active: !user.value.active,
-          is_admin: user.value.is_admin
+          active: !user.value.active
         }
       })
     }
@@ -283,7 +282,6 @@ const switchAdminAccess = async () => {
       await adminStore.updateUser({
         username: user.value.username,
         data: {
-          active: user.value.active,
           is_admin: !user.value.is_admin
         }
       })


### PR DESCRIPTION
There was bad interface in FE, where is_admin and is_active were required.