### PR TITLE
Example config for production proxy

### DIFF
--- a/ssl-proxy.conf
+++ b/ssl-proxy.conf
@@ -1,0 +1,74 @@
+
+    server {
+        listen       80;
+        server_name merginmaps.company.com;  # FIXME
+
+        if ($scheme != "https") {
+                return 301 https://$host$request_uri;
+        }
+    }
+
+    upstream app_server {
+        # route to the application proxy
+        server 127.0.0.1:8080 fail_timeout=0;
+    }
+
+    server {
+        listen              443 ssl;
+        server_name         merginmaps.company.com; # FIXME
+        client_max_body_size 4G;
+
+        ssl_certificate_key /etc/letsencrypt/live/merginmaps.company.com/privkey.pem; # FIXME
+        ssl_certificate     /etc/letsencrypt/live/merginmaps.company.com/fullchain.pem; # FIXME
+
+        # Don't show version information
+        server_tokens off;
+
+        # Enable gzip compression
+        gzip on;
+        gzip_min_length 10240;
+        gzip_comp_level 1;
+        gzip_vary on;
+        gzip_proxied expired no-cache no-store private auth;
+        gzip_types
+            text/css
+            text/javascript
+            text/xml
+            text/plain
+            text/x-component
+            application/javascript
+            application/x-javascript
+            application/json
+            application/xml
+            application/rss+xml
+            application/atom+xml
+            font/truetype
+            font/opentype
+            application/vnd.ms-fontobject
+            image/svg+xml;
+
+        # Prevent crawlers from indexing and following links for all content served from the mergin app
+        add_header X-Robots-Tag "none";
+
+        # Protect against clickjacking iframe
+        add_header Content-Security-Policy "frame-ancestors 'self';" always;
+
+        # Add a HSTS policy to prevent plain http from browser
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+        # Set cookies security flags
+        proxy_cookie_flags ~ secure httponly samesite=strict;
+
+        location / {
+            root /var/www/html;
+
+            # The lines below were copied from application proxy
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Host $http_host;
+            # we don't want nginx trying to do something clever with
+            # redirects, we set the Host: header above already.
+            proxy_redirect off;
+            proxy_pass http://app_server;
+        }
+    }


### PR DESCRIPTION
Adding an example nginx config to set up production-like proxy to merginmaps stack. It should be linked somewhere in docs.

The idea is that while simple docker-compose up should spin up the stack locally for easy testing / evaluation, for setting up production deployment more configuration steps are needed. The added example can serve either as standalone config for top level proxy webserver or as hint if someone wants to merge it with default application proxy.

Related to #94 