### PR TITLE
Proper usage of server now in db migrations

### DIFF
--- a/server/application.py
+++ b/server/application.py
@@ -66,7 +66,7 @@ def setup_periodic_tasks(sender, **kwargs):
         name="remove old project backups",
     )
     sender.add_periodic_task(
-        crontab(hour="*/12"),
+        crontab(hour="*/12", minute=0),
         save_statistics,
         name="Save usage statistics to database",
     )

--- a/server/mergin/stats/models.py
+++ b/server/mergin/stats/models.py
@@ -44,7 +44,7 @@ class MerginStatistics(db.Model):
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     created_at = db.Column(
-        db.DateTime, index=True, nullable=False, server_default="now()"
+        db.DateTime, index=True, nullable=False, default=datetime.utcnow
     )
     # data with statistics
     data = db.Column(JSONB, nullable=False)

--- a/server/migrations/community/ba5051218de4_add_mergin_statistics_table.py
+++ b/server/migrations/community/ba5051218de4_add_mergin_statistics_table.py
@@ -21,7 +21,9 @@ def upgrade():
     op.create_table(
         "mergin_statistics",
         sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
-        sa.Column("created_at", sa.DateTime(), server_default="now()", nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
         sa.Column("data", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
         sa.PrimaryKeyConstraint("id", name=op.f("pk_mergin_statistics")),
     )

--- a/web-app/packages/admin-lib/src/modules/admin/views/OverviewView.vue
+++ b/web-app/packages/admin-lib/src/modules/admin/views/OverviewView.vue
@@ -15,7 +15,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
     <app-container>
       <div class="grid" v-if="usage">
         <usage-card class="col-12 sm:col-6 lg:col-3">
-          <template #heading>Editors</template>
+          <template #heading>Contributors</template>
           <div
             class="w-full"
             :style="{


### PR DESCRIPTION
- Rename editors in overview