### PR TITLE
Drop error details index gh#2776

### DIFF
--- a/development.md
+++ b/development.md
@@ -60,7 +60,7 @@ Watching the type definitions is also useful to pick up any changes to imports o
 
 ## Running locally in a docker composition
 
-If you want to run the whole stack locally, you can use the docker. Docker will build the images from yout local files and run the services.
+If you want to run the whole stack locally, you can use the docker. Docker will build the images from your local files and run the services.
 
 ```shell
 # Run the docker composition with the current Dockerfiles

--- a/server/mergin/auth/api.yaml
+++ b/server/mergin/auth/api.yaml
@@ -682,6 +682,7 @@ paths:
           description: User info
           content:
             application/json:
+              # TODO: fix this to match the ma.SQLAlchemy schema or use UserDetail schema
               schema:
                 $ref: "#/components/schemas/UserInfo"
         "401":

--- a/server/mergin/sync/models.py
+++ b/server/mergin/sync/models.py
@@ -1121,7 +1121,7 @@ class SyncFailuresHistory(db.Model):
     error_type = db.Column(
         db.String, index=True
     )  # e.g. push_start, push_finish, push_lost
-    error_details = db.Column(db.String, index=True)
+    error_details = db.Column(db.String)
     timestamp = db.Column(db.DateTime(), default=datetime.utcnow, index=True)
     user_id = db.Column(
         db.Integer, db.ForeignKey("user.id", ondelete="SET NULL"), nullable=True

--- a/server/migrations/community/2686074eff45_ce_base.py
+++ b/server/migrations/community/2686074eff45_ce_base.py
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 
-""" Base migration for CE, reflects the state of release 2021.6.1
+"""Base migration for CE, reflects the state of release 2021.6.1
 
 Revision ID: 2686074eff45
-Revises: 
+Revises:
 Create Date: 2022-12-15 10:40:42.234210
 
 """

--- a/server/migrations/community/5ad13be6f7ef_drop_error_details_index.py
+++ b/server/migrations/community/5ad13be6f7ef_drop_error_details_index.py
@@ -1,0 +1,33 @@
+"""Drop error details index
+
+Revision ID: 5ad13be6f7ef
+Revises: ba5051218de4
+Create Date: 2025-02-20 07:52:36.670158
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from alembic import context
+
+
+# revision identifiers, used by Alembic.
+revision = '5ad13be6f7ef'
+down_revision = 'ba5051218de4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            """
+                DROP INDEX IF EXISTS ix_sync_failures_history_error_details;
+            """
+        )
+    )
+
+
+def downgrade():
+    op.create_index(op.f('ix_sync_failures_history_error_details'), 'sync_failures_history', ['error_details'],
+                    unique=False)

--- a/server/migrations/community/5ad13be6f7ef_drop_error_details_index.py
+++ b/server/migrations/community/5ad13be6f7ef_drop_error_details_index.py
@@ -5,14 +5,15 @@ Revises: ba5051218de4
 Create Date: 2025-02-20 07:52:36.670158
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 from alembic import context
 
 
 # revision identifiers, used by Alembic.
-revision = '5ad13be6f7ef'
-down_revision = 'ba5051218de4'
+revision = "5ad13be6f7ef"
+down_revision = "ba5051218de4"
 branch_labels = None
 depends_on = None
 
@@ -29,5 +30,9 @@ def upgrade():
 
 
 def downgrade():
-    op.create_index(op.f('ix_sync_failures_history_error_details'), 'sync_failures_history', ['error_details'],
-                    unique=False)
+    op.create_index(
+        op.f("ix_sync_failures_history_error_details"),
+        "sync_failures_history",
+        ["error_details"],
+        unique=False,
+    )


### PR DESCRIPTION
Fixes: [#2776](https://github.com/MerginMaps/server-private/issues/2776)

On production we'll use the following:
`DROP INDEX CONCURRENTLY IF EXISTS ix_sync_failures_history_error_details;`
to avoid downtime, instead.