### PR TITLE
Use the correct method when sharing with new user

### DIFF
--- a/web-app/packages/lib/src/modules/project/components/ProjectShareDialog.vue
+++ b/web-app/packages/lib/src/modules/project/components/ProjectShareDialog.vue
@@ -163,7 +163,7 @@ const share = async () => {
       roleName: data.permission,
       projectName: projectStore.project.name
     })
-    await projectStore.getProjectAccess(projectStore.project?.id)
+    await projectStore.getProjectCollaborators(projectStore.project?.id)
     dialogStore.close()
   } catch (err) {
     emit('onShareError', err as Error)


### PR DESCRIPTION
Fixes: https://github.com/MerginMaps/server-private/issues/2799

Problem:
For CE we use a new API to list project collaborators. We forgot to call it after the invitation is sent.

Solution:
Replace the legacy `getProjectAccess` method with the new `getProjectCollaborators`.

