### PR TITLE
Add mapper between global role and project role

### DIFF
--- a/web-app/packages/lib/src/common/permission_utils.ts
+++ b/web-app/packages/lib/src/common/permission_utils.ts
@@ -128,7 +128,12 @@ export function isAtLeastGlobalRole(
   roleName: ProjectRoleName,
   globalRole: GlobalRole
 ): boolean {
-  return PROJECT_ROLE_BY_NAME[roleName] >= globalRole
+  const globalProjectRole = {
+    [GlobalRole.global_read]: ProjectRole.reader,
+    [GlobalRole.global_write]: ProjectRole.writer,
+    [GlobalRole.global_admin]: ProjectRole.owner
+  }
+  return PROJECT_ROLE_BY_NAME[roleName] >= globalProjectRole[globalRole]
 }
 
 export function getProjectRoleNameValues(): DropdownOption<ProjectRoleName>[] {


### PR DESCRIPTION
There was issue when you had GLOBAL_ADMIN=True. Writer was not disabled in collaborators dropdown. It's caused by removing 'none' project role.

Fixed

![image](https://github.com/user-attachments/assets/d7e58419-9395-445b-8f2b-ccc0ba6f3dca)
