### PR TITLE
Fix generate_username to be case insensitive

### DIFF
--- a/server/mergin/auth/models.py
+++ b/server/mergin/auth/models.py
@@ -210,12 +210,12 @@ class User(db.Model):
             text(
                 """
                 SELECT
-                    replace(username, :username, '0')::int AS suffix
+                    replace(lower(username), :username, '0')::int AS suffix
                 FROM "user"
                 WHERE
-                    username = :username OR
-                    username SIMILAR TO :username_like
-                ORDER BY replace(username, :username, '0')::int DESC
+                    lower(username) = :username OR
+                    lower(username) SIMILAR TO :username_like
+                ORDER BY replace(lower(username), :username, '0')::int DESC
                 LIMIT 1;
                 """
             ),

--- a/server/mergin/tests/test_auth.py
+++ b/server/mergin/tests/test_auth.py
@@ -856,6 +856,13 @@ def test_username_generation(client):
         == "verylonglonglonglonglo"
     )
 
+    # test username generation with existing user, case insensitive
+    user = add_user("Testuser")
+    assert User.generate_username("Testuser@example.com") == "testuser1"
+    assert User.generate_username("testuser@example.com") == "testuser1"
+    user = add_user("testuser1")
+    assert User.generate_username("Testuser@example.com") == "testuser2"
+
 
 def test_server_usage(client):
     """Test server usage endpoint"""


### PR DESCRIPTION
For autogenerated usernames make sure we do case insensitive lookup in db.