### PR TITLE
Do not add project creator to direct project members

### DIFF
--- a/server/mergin/sync/models.py
+++ b/server/mergin/sync/models.py
@@ -90,7 +90,6 @@ class Project(db.Model):
         self.public = kwargs.get("public", False)
         latest_files = LatestProjectFiles(project=self)
         db.session.add(latest_files)
-        self.set_role(creator.id, ProjectRole.OWNER)
 
     @property
     def storage(self):

--- a/server/mergin/tests/test_celery.py
+++ b/server/mergin/tests/test_celery.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 from ..app import db
 from ..config import Configuration
-from ..sync.models import Project, AccessRequest, ProjectVersion
+from ..sync.models import Project, AccessRequest, ProjectRole, ProjectVersion
 from ..celery import send_email_async
 from ..sync.tasks import remove_temp_files, remove_projects_backups
 from ..sync.storages.disk import move_to_tmp
@@ -60,6 +60,7 @@ def test_send_email_from_flask(send_email_mock, client):
     user = User.query.filter(User.username == "mergin").first()
     test_workspace = create_workspace()
     p = create_project("testx", test_workspace, user)
+    p.set_role(user.id, ProjectRole.OWNER)
     user2 = add_user("test_user", "ilovemergin")
     login(client, "test_user", "ilovemergin")
     email_data = {

--- a/server/mergin/tests/test_project_controller.py
+++ b/server/mergin/tests/test_project_controller.py
@@ -170,7 +170,9 @@ def test_get_paginated_projects(client):
     for i in range(14):
         create_project("foo" + str(i), test_workspace, user)
 
-    resp = client.get("/v1/project/paginated?page=1&per_page=10&order_params=created_asc")
+    resp = client.get(
+        "/v1/project/paginated?page=1&per_page=10&order_params=created_asc"
+    )
     assert resp.status_code == 200
     resp_data = json.loads(resp.data)
     assert len(resp_data.get("projects")) == 10

--- a/server/mergin/tests/utils.py
+++ b/server/mergin/tests/utils.py
@@ -80,7 +80,6 @@ def create_project(name, workspace, user, **kwargs):
 
     p = Project(**project_params, **kwargs)
     p.updated = datetime.utcnow()
-    p.set_role(user.id, ProjectRole.OWNER)
     db.session.add(p)
     db.session.flush()
     changes = UploadChanges(added=[], updated=[], removed=[])


### PR DESCRIPTION
There is no need to add project creators as project owners since they must be already workspace admins. Explicit project permissions are reserved for project sharing.