### PR TITLE
Fix subfolders by regexp in /tree route + add breadcrumbs to files browser

### DIFF
--- a/web-app/packages/admin-app/src/router.ts
+++ b/web-app/packages/admin-app/src/router.ts
@@ -117,7 +117,7 @@ export const createRouter = (pinia: Pinia) => {
             props: true
           },
           {
-            path: 'tree/:location?',
+            path: 'tree/:location(.*)?',
             name: AdminRoutes.ProjectTree,
             component: ProjectFilesView,
             props: true

--- a/web-app/packages/app/src/router.ts
+++ b/web-app/packages/app/src/router.ts
@@ -186,12 +186,12 @@ export const createRouter = (pinia: Pinia) => {
         meta: {
           breadcrump: [{ title: 'Projects', path: '/projects' }]
         },
-        redirect: { name: 'project-tree' },
+        redirect: { name: ProjectRouteName.ProjectTree },
 
         children: [
           {
-            path: 'tree/:location?',
-            name: 'project-tree',
+            path: 'tree/:location(.*)?',
+            name: ProjectRouteName.ProjectTree,
             component: FileBrowserView,
             props: true,
             meta: { public: true }

--- a/web-app/packages/lib/src/modules/project/components/FilesTable.vue
+++ b/web-app/packages/lib/src/modules/project/components/FilesTable.vue
@@ -172,7 +172,7 @@ const breadcrumps = computed(() => {
   return [
     {
       icon: 'ti ti-folder',
-      label: 'Project home',
+      label: 'Files',
       path: folderLink(''),
       active: parts.length === 0
     },

--- a/web-app/packages/lib/src/modules/project/views/FileBrowserView.vue
+++ b/web-app/packages/lib/src/modules/project/views/FileBrowserView.vue
@@ -6,38 +6,6 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 
 <template>
   <div>
-    <!-- Searching -->
-    <app-container
-      v-if="searchFilter !== '' || Object.keys(project?.files ?? {}).length > 0"
-    >
-      <app-section ground>
-        <div class="flex align-items-center">
-          <span class="p-input-icon-left flex-grow-1">
-            <i class="ti ti-search paragraph-p3"></i>
-            <PInputText
-              placeholder="Search files"
-              data-cy="search-files-field"
-              v-model="searchFilter"
-              class="w-full"
-            />
-          </span>
-          <AppMenu :items="filterMenuItems" />
-        </div>
-      </app-section>
-    </app-container>
-
-    <app-container v-if="dataTableOpen && projectName">
-      <app-section>
-        <files-table
-          :project-name="projectName"
-          :namespace="namespace"
-          :location="location"
-          :options="options"
-          :search="searchFilter"
-          @row-click="rowClick"
-        />
-      </app-section>
-    </app-container>
     <app-container
       v-if="project && $route.name === 'project-tree' && isProjectWriter"
     >
@@ -76,6 +44,38 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
           </div>
         </div>
       </app-panel-toggleable>
+    </app-container>
+    <!-- Searching -->
+    <app-container
+      v-if="searchFilter !== '' || Object.keys(project?.files ?? {}).length > 0"
+    >
+      <app-section ground>
+        <div class="flex align-items-center">
+          <span class="p-input-icon-left flex-grow-1">
+            <i class="ti ti-search paragraph-p3"></i>
+            <PInputText
+              placeholder="Search files"
+              data-cy="search-files-field"
+              v-model="searchFilter"
+              class="w-full"
+            />
+          </span>
+          <AppMenu :items="filterMenuItems" />
+        </div>
+      </app-section>
+    </app-container>
+
+    <app-container v-if="dataTableOpen && projectName">
+      <app-section>
+        <files-table
+          :project-name="projectName"
+          :namespace="namespace"
+          :location="location"
+          :options="options"
+          :search="searchFilter"
+          @row-click="rowClick"
+        />
+      </app-section>
     </app-container>
     <!-- Sidebars -->
     <file-detail-sidebar :namespace="namespace" :project-name="projectName" />

--- a/web-app/packages/lib/src/modules/project/views/FileBrowserView.vue
+++ b/web-app/packages/lib/src/modules/project/views/FileBrowserView.vue
@@ -26,6 +26,18 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
       </app-section>
     </app-container>
 
+    <app-container v-if="dataTableOpen && projectName">
+      <app-section>
+        <files-table
+          :project-name="projectName"
+          :namespace="namespace"
+          :location="location"
+          :options="options"
+          :search="searchFilter"
+          @row-click="rowClick"
+        />
+      </app-section>
+    </app-container>
     <app-container
       v-if="project && $route.name === 'project-tree' && isProjectWriter"
     >
@@ -64,19 +76,6 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
           </div>
         </div>
       </app-panel-toggleable>
-    </app-container>
-
-    <app-container v-if="dataTableOpen && projectName">
-      <app-section>
-        <files-table
-          :project-name="projectName"
-          :namespace="namespace"
-          :location="location"
-          :options="options"
-          :search="searchFilter"
-          @row-click="rowClick"
-        />
-      </app-section>
     </app-container>
     <!-- Sidebars -->
     <file-detail-sidebar :namespace="namespace" :project-name="projectName" />

--- a/web-app/packages/lib/src/modules/project/views/ProjectCollaboratorsViewTemplate.vue
+++ b/web-app/packages/lib/src/modules/project/views/ProjectCollaboratorsViewTemplate.vue
@@ -12,7 +12,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
       <app-section
         ><template #title
           >Requests
-          <span class="opacity-80"
+          <span class="text-color-medium-green"
             >({{ projectStore.accessRequestsCount }})</span
           ></template
         ><project-access-requests


### PR DESCRIPTION
Fixes #230 

Fixed :hammer: 
- There was not found page in case of sub folders. Fixed by adding regexp lookup for location to router. Needs to be modified in every router, as routers are separated between apps.

Added :hammer: :heavy_plus_sign: 
- get rid of ".." to get parent folder from sub folder (we can use breadcrumbs instead)
- move upload to top of page to have search and files together
- introduce breadcrumbs to files browser

https://github.com/user-attachments/assets/c207d4a8-286a-4fba-9d26-83b6f43e54ed


