### PR TITLE
Don't allow SSO users update their profile

### DIFF
--- a/server/mergin/auth/api.yaml
+++ b/server/mergin/auth/api.yaml
@@ -895,6 +895,8 @@ components:
                 example: my-workspace
               role:
                 $ref: "#/components/schemas/WorkspaceRole"
+        can_edit_profile:
+          type: boolean
     LoginResponse:
       allOf:
         - $ref: "#/components/schemas/UserDetail"

--- a/server/mergin/auth/api.yaml
+++ b/server/mergin/auth/api.yaml
@@ -466,6 +466,8 @@ paths:
           description: OK
         "400":
           $ref: "#/components/responses/BadStatusResp"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFoundResp"
   /app/auth/confirm-email/{token}:

--- a/server/mergin/auth/api.yaml
+++ b/server/mergin/auth/api.yaml
@@ -68,8 +68,8 @@ paths:
     post:
       tags:
         - user
-      summary: Update profile of user in sesssion
-      description: Update profile of user in sesssion
+      summary: Update profile of user in session
+      description: Update profile of user in session
       operationId: mergin.auth.controller.update_user_profile
       requestBody:
         description: Updated profile
@@ -101,6 +101,8 @@ paths:
           $ref: "#/components/responses/BadStatusResp"
         "401":
           $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/Forbidden"
   /app/auth/refresh/csrf:
     get:
       summary: Get refreshed csrf token
@@ -426,6 +428,8 @@ paths:
           description: OK
         "400":
           $ref: "#/components/responses/BadStatusResp"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFoundResp"
   /app/auth/reset-password/{token}:

--- a/server/mergin/auth/app.py
+++ b/server/mergin/auth/app.py
@@ -11,7 +11,7 @@ from sqlalchemy import func
 
 from .commands import add_commands
 from .config import Configuration
-from .models import User, UserProfile
+from .models import User
 
 # signal for other versions to listen to
 user_account_closed = signal("user_account_closed")
@@ -67,6 +67,17 @@ def auth_required(f=None, permissions=None):
                     return "Permission denied.", 403
         return f(*args, **kwargs)
 
+    return wrapped_func
+
+
+def edit_profile_enabled(f):
+    from .controller import CANNOT_EDIT_PROFILE_MSG
+
+    @functools.wraps(f)
+    def wrapped_func(*args, **kwargs):
+        if not current_user.can_edit_profile:
+            return CANNOT_EDIT_PROFILE_MSG, 403
+        return f(*args, **kwargs)
     return wrapped_func
 
 

--- a/server/mergin/auth/app.py
+++ b/server/mergin/auth/app.py
@@ -78,6 +78,7 @@ def edit_profile_enabled(f):
         if not current_user.can_edit_profile:
             return CANNOT_EDIT_PROFILE_MSG, 403
         return f(*args, **kwargs)
+
     return wrapped_func
 
 

--- a/server/mergin/auth/app.py
+++ b/server/mergin/auth/app.py
@@ -17,6 +17,8 @@ from .models import User
 user_account_closed = signal("user_account_closed")
 user_created = signal("user_created")
 
+CANNOT_EDIT_PROFILE_MSG = "You cannot edit profile of this user"
+
 
 def register(app):
     """Register mergin auth module in Flask app
@@ -71,10 +73,12 @@ def auth_required(f=None, permissions=None):
 
 
 def edit_profile_enabled(f):
-    from .controller import CANNOT_EDIT_PROFILE_MSG
+    """Decorator to check if user can edit their profile (it is not allowed for SSO users)"""
 
     @functools.wraps(f)
     def wrapped_func(*args, **kwargs):
+        if not current_user or not current_user.is_authenticated:
+            return "Authentication information is missing or invalid.", 401
         if not current_user.can_edit_profile:
             return CANNOT_EDIT_PROFILE_MSG, 403
         return f(*args, **kwargs)

--- a/server/mergin/auth/controller.py
+++ b/server/mergin/auth/controller.py
@@ -21,6 +21,7 @@ from .app import (
     user_created,
     user_account_closed,
     edit_profile_enabled,
+    CANNOT_EDIT_PROFILE_MSG,
 )
 from .bearer import encode_token
 from .models import User, LoginHistory, UserProfile
@@ -41,7 +42,6 @@ from ..sync.utils import files_size
 
 
 EMAIL_CONFIRMATION_EXPIRATION = 12 * 3600
-CANNOT_EDIT_PROFILE_MSG = "You cannot edit profile of this user"
 
 
 # public endpoints
@@ -258,8 +258,6 @@ def logout():  # pylint: disable=W0613,W0612
 @auth_required
 @edit_profile_enabled
 def change_password():  # pylint: disable=W0613,W0612
-    if not current_user.can_edit_profile:
-        abort(403, CANNOT_EDIT_PROFILE_MSG)
     form = UserChangePasswordForm()
     if form.validate_on_submit():
         if not current_user.check_password(form.old_password.data):
@@ -275,8 +273,6 @@ def change_password():  # pylint: disable=W0613,W0612
 @auth_required
 @edit_profile_enabled
 def resend_confirm_email():  # pylint: disable=W0613,W0612
-    if not current_user.can_edit_profile:
-        abort(403, CANNOT_EDIT_PROFILE_MSG)
     send_confirmation_email(
         current_app,
         current_user,
@@ -360,8 +356,6 @@ def confirm_email(token):  # pylint: disable=W0613,W0612
 @auth_required
 @edit_profile_enabled
 def update_user_profile():  # pylint: disable=W0613,W0612
-    if not current_user.can_edit_profile:
-        abort(403, CANNOT_EDIT_PROFILE_MSG)
     form = UserProfileDataForm.from_json(request.json)
     email_changed = current_user.email != form.email.data.strip()
     if not form.validate_on_submit():

--- a/server/mergin/auth/controller.py
+++ b/server/mergin/auth/controller.py
@@ -20,6 +20,7 @@ from .app import (
     generate_confirmation_token,
     user_created,
     user_account_closed,
+    edit_profile_enabled,
 )
 from .bearer import encode_token
 from .models import User, LoginHistory, UserProfile
@@ -255,6 +256,7 @@ def logout():  # pylint: disable=W0613,W0612
 
 
 @auth_required
+@edit_profile_enabled
 def change_password():  # pylint: disable=W0613,W0612
     if not current_user.can_edit_profile:
         abort(403, CANNOT_EDIT_PROFILE_MSG)
@@ -271,6 +273,7 @@ def change_password():  # pylint: disable=W0613,W0612
 
 
 @auth_required
+@edit_profile_enabled
 def resend_confirm_email():  # pylint: disable=W0613,W0612
     if not current_user.can_edit_profile:
         abort(403, CANNOT_EDIT_PROFILE_MSG)
@@ -355,6 +358,7 @@ def confirm_email(token):  # pylint: disable=W0613,W0612
 
 
 @auth_required
+@edit_profile_enabled
 def update_user_profile():  # pylint: disable=W0613,W0612
     if not current_user.can_edit_profile:
         abort(403, CANNOT_EDIT_PROFILE_MSG)

--- a/server/mergin/auth/models.py
+++ b/server/mergin/auth/models.py
@@ -239,6 +239,7 @@ class User(db.Model):
     @property
     def can_edit_profile(self) -> bool:
         """Flag if we allow user to edit their email and name"""
+        # False when user is created by SSO login
         return self.passwd is not None
 
 

--- a/server/mergin/auth/models.py
+++ b/server/mergin/auth/models.py
@@ -42,7 +42,7 @@ class User(db.Model):
     )
 
     def __init__(self, username, email, passwd=None, is_admin=False):
-        self.username = username or self.generate_username(email)
+        self.username = username
         self.email = email
         self.assign_password(passwd)
         self.is_admin = is_admin
@@ -244,7 +244,7 @@ class User(db.Model):
     def can_edit_profile(self) -> bool:
         """Flag if we allow user to edit their email and name"""
         # False when user is created by SSO login
-        return self.passwd is not None
+        return self.passwd is not None and self.active
 
 
 class UserProfile(db.Model):

--- a/server/mergin/auth/models.py
+++ b/server/mergin/auth/models.py
@@ -236,6 +236,11 @@ class User(db.Model):
         db.session.commit()
         return user
 
+    @property
+    def can_edit_profile(self) -> bool:
+        """Flag if we allow user to edit their email and name"""
+        return self.passwd is not None
+
 
 class UserProfile(db.Model):
     user_id = db.Column(

--- a/server/mergin/auth/models.py
+++ b/server/mergin/auth/models.py
@@ -58,7 +58,11 @@ class User(db.Model):
     def assign_password(self, password):
         if isinstance(password, str):
             password = password.encode("utf-8")
-        self.passwd = bcrypt.hashpw(password, bcrypt.gensalt()).decode("utf-8") if password else None
+        self.passwd = (
+            bcrypt.hashpw(password, bcrypt.gensalt()).decode("utf-8")
+            if password
+            else None
+        )
 
     @property
     def is_authenticated(self):

--- a/server/mergin/auth/models.py
+++ b/server/mergin/auth/models.py
@@ -41,8 +41,8 @@ class User(db.Model):
         db.Index("ix_user_email", func.lower(email), unique=True),
     )
 
-    def __init__(self, username, email, passwd, is_admin=False):
-        self.username = username
+    def __init__(self, username, email, passwd=None, is_admin=False):
+        self.username = username or self.generate_username(email)
         self.email = email
         self.assign_password(passwd)
         self.is_admin = is_admin
@@ -58,7 +58,7 @@ class User(db.Model):
     def assign_password(self, password):
         if isinstance(password, str):
             password = password.encode("utf-8")
-        self.passwd = bcrypt.hashpw(password, bcrypt.gensalt()).decode("utf-8")
+        self.passwd = bcrypt.hashpw(password, bcrypt.gensalt()).decode("utf-8") if password else None
 
     @property
     def is_authenticated(self):

--- a/server/mergin/auth/schemas.py
+++ b/server/mergin/auth/schemas.py
@@ -101,6 +101,7 @@ class UserInfoSchema(ma.SQLAlchemyAutoSchema):
     receive_notifications = fields.Boolean(attribute="profile.receive_notifications")
     registration_date = DateTimeWithZ(attribute="registration_date")
     name = fields.Function(lambda obj: obj.profile.name())
+    can_edit_profile = fields.Boolean(attribute="can_edit_profile")
 
     class Meta:
         model = User

--- a/server/mergin/tests/test_auth.py
+++ b/server/mergin/tests/test_auth.py
@@ -510,9 +510,7 @@ def test_update_user_profile(client):
     db.session.commit()
     resp = client.post(
         url_for("/.mergin_auth_controller_update_user_profile"),
-        data=json.dumps(
-            {"email": "changed_email@sso.co.uk"}
-        ),
+        data=json.dumps({"email": "changed_email@sso.co.uk"}),
         headers=json_headers,
     )
     assert resp.status_code == 403

--- a/server/mergin/tests/test_auth.py
+++ b/server/mergin/tests/test_auth.py
@@ -453,6 +453,17 @@ def test_update_user(client):
     )
     assert resp.status_code == 403
 
+    #  do not allow to update sso user
+    sso_user = User("", email="user@sso.com")
+    db.session.add(sso_user)
+    db.session.commit()
+    resp = client.patch(
+        url_for("/.mergin_auth_controller_update_user", username=sso_user.username),
+        data=json.dumps(data),
+        headers=json_headers,
+    )
+    assert resp.status_code == 403
+
 
 def test_update_user_profile(client):
     login_as_admin(client)

--- a/web-app/packages/lib/src/modules/user/types.ts
+++ b/web-app/packages/lib/src/modules/user/types.ts
@@ -66,6 +66,7 @@ export interface UserDetailResponse extends UserProfileResponse {
   receive_notifications: boolean
   registration_date: string
   workspaces: UserWorkspace[]
+  can_edit_profile: boolean
 }
 
 export interface WorkspaceResponse extends UserWorkspace {

--- a/web-app/packages/lib/src/modules/user/views/ProfileViewTemplate.vue
+++ b/web-app/packages/lib/src/modules/user/views/ProfileViewTemplate.vue
@@ -12,7 +12,10 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
       >
         <!-- Title with buttons -->
         <h1 class="headline-h3 text-color font-semibold">Account details</h1>
-        <div class="flex flex-grow-1 align-items-center lg:justify-content-end">
+        <div
+          v-if="loggedUser.can_edit_profile"
+          class="flex flex-grow-1 align-items-center lg:justify-content-end"
+        >
           <PButton
             @click="editProfileDialog"
             icon="ti ti-pencil"


### PR DESCRIPTION
Users that signed in with SSO are not allowed to change their email, name or password.

Frontend does not show the button to update the profile. :empty_nest: 

Backend blocks profile update :no_entry: 

![image](https://github.com/user-attachments/assets/f573e9f6-541d-4825-a07c-5271c909023f)

Unittest only for admin endpoint as I'm not able to login as SSO user (right now)
