### PR TITLE
Allow configure lifetime of flask sessions

### DIFF
--- a/server/mergin/auth/config.py
+++ b/server/mergin/auth/config.py
@@ -13,3 +13,6 @@ class Configuration(object):
         "BEARER_TOKEN_EXPIRATION", default=3600 * 12, cast=int
     )  # in seconds
     ACCOUNT_EXPIRATION = config("ACCOUNT_EXPIRATION", default=5, cast=int)  # in days
+    PERMANENT_SESSION_LIFETIME = config(
+        "PERMANENT_SESSION_LIFETIME", default=60 * 60 * 24 * 31, cast=int
+    )  # in seconds, 30 days. Flask specific variable to handle session lifetime.


### PR DESCRIPTION
There are two options for flask session management. 
- `session.permanent=True` (or SESSION_PERMANENT env variable) to make web session permanent.
- `session.permanent=False - session is store in browser no expiration date (expiration is based on opened browser tab or rememeber tabs option) - **default**

Note: We are not able to set session.permanent with standard `flask-login` flow, because there is REMEMBER login mechanism as replacement for permanent session cookies. You can set some option to remember cookies token by these variables  https://flask-login.readthedocs.io/en/latest/index.html#cookie-settings.

So why we make this option available? `PERMANENT_SESSION_LIFETIME` is not affecting just session.permanent=True sessions. It's checking lifetime session cookies without expiration date too. For better control, we could make available this option.

**Example**

- descrease PERMENANET_SESSION_LIFETIME to some seconds
- login
- refresh browser
- you are automagically signed out

```
PERMANENT_SESSION_LIFETIME

    If session.permanent is true, the cookie’s expiration will be set this number of seconds in the future. Can either be a [datetime.timedelta](https://docs.python.org/3/library/datetime.html#datetime.timedelta) or an int.

    Flask’s default cookie implementation validates that the cryptographic signature is not older than this value.

    Default: timedelta(days=31) (2678400 seconds)
```

I think we can life with default value 31. But for someone could be interesting to make it shorter.