### PR TITLE
Send corresponding signal whenever new project member is added

### DIFF
--- a/server/mergin/sync/models.py
+++ b/server/mergin/sync/models.py
@@ -35,6 +35,7 @@ from .utils import is_versioned_file, is_qgis
 
 Storages = {"local": DiskStorage}
 project_deleted = signal("project_deleted")
+project_access_granted = signal("project_access_granted")
 
 
 class PushChangeType(Enum):
@@ -272,6 +273,7 @@ class Project(db.Model):
         if member:
             member.role = role.value
         else:
+            project_access_granted.send(self, user_id=user_id)
             self.project_users.append(ProjectUser(user_id=user_id, role=role.value))
 
     def unset_role(self, user_id: int) -> None:

--- a/server/mergin/sync/private_api_controller.py
+++ b/server/mergin/sync/private_api_controller.py
@@ -44,8 +44,6 @@ from .tasks import create_project_version_zip
 from .storages.disk import move_to_tmp
 from .utils import get_x_accel_uri
 
-project_access_granted = signal("project_access_granted")
-
 
 @auth_required
 def create_project_access_request(namespace, project_name):  # noqa: E501
@@ -136,9 +134,6 @@ def accept_project_access_request(request_id):
     project_role = ProjectPermissions.get_user_project_role(project, current_user)
     if project_role == ProjectRole.OWNER:
         access_request.accept(permission)
-        project_access_granted.send(
-            access_request.project, user_id=access_request.requested_by
-        )
         return "", 200
     abort(403, "You don't have permissions to accept project access request")
 

--- a/server/mergin/sync/public_api_v2_controller.py
+++ b/server/mergin/sync/public_api_v2_controller.py
@@ -16,7 +16,6 @@ from ..auth import auth_required
 from ..auth.models import User
 from .models import Project, ProjectRole, ProjectMember
 from .permissions import ProjectPermissions, require_project_by_uuid
-from .private_api_controller import project_access_granted
 
 
 @auth_required
@@ -101,7 +100,6 @@ def add_project_collaborator(id):
 
     project.set_role(user.id, ProjectRole(request.json["role"]))
     db.session.commit()
-    project_access_granted.send(project, user_id=user.id)
     data = ProjectMemberSchema().dump(project.get_member(user.id))
     return data, 201
 


### PR DESCRIPTION
Make sure that we send proper signal before a new project member is added. This way we can assure workspace permissions will be adjusted accordingly.