### PR TITLE
Fix get_x_accel uri for absolute paths

### DIFF
--- a/server/mergin/sync/utils.py
+++ b/server/mergin/sync/utils.py
@@ -575,5 +575,6 @@ def get_x_accel_uri(*url_parts):
     # if the path parts_join starts with local_projects, remove it
     if url.startswith(local_projects):
         url = os.path.relpath(url, local_projects)
+    url = url.lstrip(os.path.sep)
     result = os.path.join(download_accell_uri, url)
     return result

--- a/server/mergin/tests/test_utils.py
+++ b/server/mergin/tests/test_utils.py
@@ -270,3 +270,9 @@ def test_get_x_accell_uri(client):
 
     url_parts = ()
     assert get_x_accel_uri(*url_parts) == "/download"
+
+    url_parts = ("/archive", "cc900b78-a8b2-4e80-b546-74c96584bd10-v4.zip")
+    assert (
+        get_x_accel_uri(*url_parts)
+        == "/download/archive/cc900b78-a8b2-4e80-b546-74c96584bd10-v4.zip"
+    )


### PR DESCRIPTION
Fix rewrite for x_accel_uri when absolute path is sent in argument. This is useful when `PROJECTS_ARCHIVES_DIR` is mounted to separate folder, different than local projects.