### PR TITLE
Breacrumbs fix + small app header enhancements

### DIFF
--- a/web-app/packages/app/src/router.ts
+++ b/web-app/packages/app/src/router.ts
@@ -194,75 +194,82 @@ export const createRouter = (pinia: Pinia) => {
             name: ProjectRouteName.ProjectTree,
             component: FileBrowserView,
             props: true,
-            meta: { public: true }
+            meta: {
+              public: true,
+              breadcrump: (route) => [
+                {
+                  title: route.params?.projectName,
+                  path: `/projects/${route.params.namespace}/${route.params.projectName}/tree`
+                }
+              ]
+            }
           },
           {
             path: 'settings',
             name: 'project-settings',
             component: ProjectSettingsView,
-            props: true
+            props: true,
+            meta: {
+              breadcrump: (route) => [
+                {
+                  title: route.params?.projectName,
+                  path: `/projects/${route.params.namespace}/${route.params.projectName}/tree`
+                }
+              ]
+            }
           },
           {
             path: 'history',
             name: 'project-versions',
             component: ProjectVersionsView,
-            props: true
+            props: true,
+            meta: {
+              breadcrump: (route) => [
+                {
+                  title: route.params?.projectName,
+                  path: `/projects/${route.params.namespace}/${route.params.projectName}/tree`
+                }
+              ]
+            }
           },
           {
             path: 'collaborators',
             name: ProjectRouteName.ProjectCollaborators,
             component: ProjectCollaboratorsView,
-            props: true
+            props: true,
+            meta: {
+              breadcrump: (route) => [
+                {
+                  title: route.params?.projectName,
+                  path: `/projects/${route.params.namespace}/${route.params.projectName}/tree`
+                }
+              ]
+            }
           },
           {
             path: 'history/:version_id/:path',
             name: 'file-version-detail',
             component: FileVersionDetailView,
             props: true,
-            meta: { public: true },
-            // TODO: refactor to function in utils
-            beforeEnter(to, from, next) {
-              to.meta = {
-                ...to.meta,
-                breadcrump: [
-                  {
-                    title: String(to.params.projectName),
-                    path: `/projects/${to.params.namespace}/${to.params.projectName}/history`
-                  },
-                  {
-                    title: String(to.params.version_id),
-                    path: `/projects/${to.params.namespace}/${to.params.projectName}/history/${to.params.version_id}`
-                  },
-                  {
-                    title: String(to.params.path),
-                    path: to.fullPath
-                  }
-                ]
-              }
-              next()
+            meta: {
+              public: true,
+              breadcrump: (route) => [
+                {
+                  title: route.params?.projectName,
+                  path: `/projects/${route.params.namespace}/${route.params.projectName}/tree`
+                },
+                {
+                  title: route.params?.version_id,
+                  path: `/projects/${route.params.namespace}/${route.params.projectName}/history/${route.params.version_id}`
+                },
+                {
+                  title: route.params?.path,
+                  path: route.fullPath
+                }
+              ]
             }
           }
         ]
-          // Not apply for project version detail , which have own breadcrump
-          .map((child) =>
-            child.name === 'file-version-detail'
-              ? child
-              : {
-                  ...child,
-                  beforeEnter: (to, from, next) => {
-                    to.meta = {
-                      ...to.meta,
-                      breadcrump: [
-                        {
-                          title: String(to.params.projectName),
-                          path: to.fullPath
-                        }
-                      ]
-                    }
-                    next()
-                  }
-                }
-          )
       },
       {
         path: '/:pathMatch(.*)*',

--- a/web-app/packages/app/src/shims-vue-router.d.ts
+++ b/web-app/packages/app/src/shims-vue-router.d.ts
@@ -4,6 +4,8 @@ declare module 'vue-router' {
   interface RouteMeta {
     public?: boolean
     allowedForNoWorkspace?: boolean
-    breadcrump?: { title: string; path: string }[]
+    breadcrump?:
+      | { title: string; path: string }[]
+      | ((route) => { title: string; path: string }[])
   }
 }

--- a/web-app/packages/lib/src/modules/layout/components/AppHeaderTemplate.vue
+++ b/web-app/packages/lib/src/modules/layout/components/AppHeaderTemplate.vue
@@ -73,6 +73,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             label="Sign in"
           />
           <POverlayPanel
+            v-if="loggedUser"
             id="app-header-profile"
             data-cy="app-header-profile"
             ref="menu"

--- a/web-app/packages/lib/src/modules/layout/components/AppHeaderTemplate.vue
+++ b/web-app/packages/lib/src/modules/layout/components/AppHeaderTemplate.vue
@@ -61,6 +61,17 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
             </div>
             <i class="ti ti-chevron-down"></i
           ></PButton>
+          <PButton
+            v-else
+            text
+            plain
+            aria-haspopup="true"
+            aria-controls="app-header-profile"
+            data-cy="app-header-profile-btn"
+            @click="login"
+            class="p-2 shadow-none"
+            label="Sign in"
+          />
           <POverlayPanel
             id="app-header-profile"
             data-cy="app-header-profile"
@@ -228,6 +239,10 @@ export default defineComponent({
       } catch (e) {
         console.error(e)
       }
+    },
+
+    login() {
+      this.$router.push({ name: UserRouteName.Login })
     }
   }
 })

--- a/web-app/packages/lib/src/modules/layout/components/AppHeaderTemplate.vue
+++ b/web-app/packages/lib/src/modules/layout/components/AppHeaderTemplate.vue
@@ -38,6 +38,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
       <template #end>
         <div class="flex align-items-center flex-shrink-0">
           <PButton
+            v-if="loggedUser"
             text
             plain
             aria-haspopup="true"
@@ -187,7 +188,7 @@ export default defineComponent({
         {
           label: 'Documentation',
           url: this.configData?.docs_url,
-          target: '_blank',
+          target: '_blank'
         },
         {
           label: 'Community chat',

--- a/web-app/packages/lib/src/modules/layout/store.ts
+++ b/web-app/packages/lib/src/modules/layout/store.ts
@@ -11,7 +11,6 @@ export interface LayoutState {
   isUnderOverlayBreakpoint: boolean
   /** Parsed closed elements from local storage and pushed back to local storage */
   closedElements: string[]
-  breadcrumps: { title: string; path: string }[]
 }
 
 const CLOSED_ELEMENTS_KEY = 'mm-closed-elements'
@@ -21,8 +20,7 @@ export const useLayoutStore = defineStore('layoutModule', {
     overlayBreakpoint: 1200,
     drawer: false,
     isUnderOverlayBreakpoint: false,
-    closedElements: [],
-    breadcrumps: []
+    closedElements: []
   }),
   getters: {
     /**

--- a/web-app/packages/lib/src/shims-vue-router.d.ts
+++ b/web-app/packages/lib/src/shims-vue-router.d.ts
@@ -4,6 +4,8 @@ declare module 'vue-router' {
   interface RouteMeta {
     public?: boolean
     allowedForNoWorkspace?: boolean
-    breadcrump?: { title: string; path: string }[]
+    breadcrump?:
+      | { title: string; path: string }[]
+      | ((route) => { title: string; path: string }[])
   }
 }


### PR DESCRIPTION
Fixed :hammer: 

- app breadcrumbs component now accepts also function in meta, where are parsed route params
- there was issue with beforeEnter handler, where meta was not provided properly
- switching breadcrumbs in case of files or version details are showing

![Screenshot from 2025-05-30 14-34-46](https://github.com/user-attachments/assets/5904793a-8e44-42e5-a898-14e7bc63a77a)

Enhancements:

- add sign in button for public view of projects
- get rid of console error in case of non logged user