### PR TITLE
Refactor upload changes handling

### DIFF
--- a/server/mergin/sync/commands.py
+++ b/server/mergin/sync/commands.py
@@ -9,7 +9,6 @@ import secrets
 from datetime import datetime
 from flask import Flask, current_app
 
-from .files import UploadChanges
 from ..app import db
 from .models import Project, ProjectVersion
 from .utils import split_project_path
@@ -52,8 +51,7 @@ def add_commands(app: Flask):
         p = Project(**project_params)
         p.updated = datetime.utcnow()
         db.session.add(p)
-        changes = UploadChanges(added=[], updated=[], removed=[])
-        pv = ProjectVersion(p, 0, user.id, changes, "127.0.0.1")
+        pv = ProjectVersion(p, 0, user.id, [], "127.0.0.1")
         pv.project = p
         db.session.commit()
         os.makedirs(p.storage.project_dir, exist_ok=True)

--- a/server/mergin/sync/files.py
+++ b/server/mergin/sync/files.py
@@ -3,12 +3,27 @@
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 import datetime
 import os
+import uuid
 from dataclasses import dataclass
-from typing import Optional, List
-from marshmallow import fields, EXCLUDE, pre_load, post_load, post_dump
+from enum import Enum
+from flask import current_app
+from marshmallow import ValidationError, fields, EXCLUDE, post_dump, validates_schema
 from pathvalidate import sanitize_filename
+from typing import Optional, List
 
+from .utils import is_file_name_blacklisted, is_qgis, is_versioned_file
 from ..app import DateTimeWithZ, ma
+
+
+class PushChangeType(Enum):
+    CREATE = "create"
+    UPDATE = "update"
+    DELETE = "delete"
+    UPDATE_DIFF = "update_diff"
+
+    @classmethod
+    def values(cls):
+        return [member.value for member in cls.__members__.values()]
 
 
 def mergin_secure_filename(filename: str) -> str:
@@ -24,12 +39,11 @@ def mergin_secure_filename(filename: str) -> str:
 
 @dataclass
 class File:
-    """Base class for every file object"""
+    """Base class for every file object, either intended to upload or already existing in project"""
 
     path: str
     checksum: str
     size: int
-    location: str
 
     def is_valid_gpkg(self):
         """Check if diff file is valid"""
@@ -37,81 +51,169 @@ class File:
 
 
 @dataclass
+class ProjectDiffFile(File):
+    """Metadata for geodiff diff file (aka. changeset) associated with geopackage"""
+
+    # location where file is actually stored
+    location: str
+
+
+@dataclass
 class ProjectFile(File):
-    """Project file metadata including metadata for diff file"""
+    """Project file metadata including metadata for diff file and location where it is stored"""
 
     # metadata for gpkg diff file
-    diff: Optional[File]
+    diff: Optional[ProjectDiffFile]
     # deprecated attribute kept for public API compatibility
     mtime: Optional[datetime.datetime]
+    # location where file is actually stored
+    location: str
 
 
 @dataclass
-class UploadFile(File):
-    """File to be uploaded coming from client push process"""
+class ProjectFileChange(ProjectFile):
+    """Metadata of changed file in project version.
 
-    # determined by client
-    chunks: Optional[List[str]]
-    diff: Optional[File]
+    This item is saved into database into file_history.
+    """
+
+    change: PushChangeType
 
 
-@dataclass
-class UploadChanges:
-    added: List[UploadFile]
-    updated: List[UploadFile]
-    removed: List[UploadFile]
+def files_changes_from_upload(changes: dict, version: int) -> List["ProjectFileChange"]:
+    """Create a list of version file changes from upload changes dictionary used by public API.
+
+    It flattens changes dict and adds change type to each item. Also generates location for each file.
+    """
+    secure_filenames = []
+    version_changes = []
+    version = "v" + str(version)
+    for key in ("added", "updated", "removed"):
+        for item in changes.get(key, []):
+            location = os.path.join(version, mergin_secure_filename(item["path"]))
+            diff = None
+
+            # make sure we have unique location for each file
+            if location in secure_filenames:
+                filename, file_extension = os.path.splitext(location)
+                location = filename + f".{str(uuid.uuid4())}" + file_extension
+
+            secure_filenames.append(location)
+
+            if key == "removed":
+                change = PushChangeType.DELETE
+                location = None
+            elif key == "added":
+                change = PushChangeType.CREATE
+            else:
+                change = PushChangeType.UPDATE
+                if item.get("diff"):
+                    change = PushChangeType.UPDATE_DIFF
+                    diff_location = os.path.join(
+                        version, mergin_secure_filename(item["diff"]["path"])
+                    )
+                    if diff_location in secure_filenames:
+                        filename, file_extension = os.path.splitext(diff_location)
+                        diff_location = (
+                            filename + f".{str(uuid.uuid4())}" + file_extension
+                        )
+
+                    secure_filenames.append(diff_location)
+                    diff = ProjectDiffFile(
+                        path=item["diff"]["path"],
+                        checksum=item["diff"]["checksum"],
+                        size=item["diff"]["size"],
+                        location=diff_location,
+                    )
+
+            file_change = ProjectFileChange(
+                path=item["path"],
+                checksum=item["checksum"],
+                size=item["size"],
+                mtime=None,
+                change=change,
+                location=location,
+                diff=diff,
+            )
+            version_changes.append(file_change)
+
+    return version_changes
 
 
 class FileSchema(ma.Schema):
     path = fields.String()
     size = fields.Integer()
     checksum = fields.String()
-    location = fields.String(load_default="", load_only=True)
 
     class Meta:
         unknown = EXCLUDE
-
-    @post_load
-    def create_obj(self, data, **kwargs):
-        return File(**data)
 
 
 class UploadFileSchema(FileSchema):
     chunks = fields.List(fields.String(), load_default=[])
     diff = fields.Nested(FileSchema(), many=False, load_default=None)
 
-    @pre_load
-    def pre_load(self, data, **kwargs):
-        # add future location based on context version
-        version = f"v{self.context.get('version')}"
-        if not data.get("location"):
-            data["location"] = os.path.join(
-                version, mergin_secure_filename(data["path"])
-            )
-        if data.get("diff") and not data.get("diff").get("location"):
-            data["diff"]["location"] = os.path.join(
-                version, mergin_secure_filename(data["diff"]["path"])
-            )
-        return data
-
-    @post_load
-    def create_obj(self, data, **kwargs):
-        return UploadFile(**data)
-
 
 class ChangesSchema(ma.Schema):
     """Schema for upload changes"""
 
-    added = fields.List(fields.Nested(UploadFileSchema()), load_default=[])
-    updated = fields.List(fields.Nested(UploadFileSchema()), load_default=[])
-    removed = fields.List(fields.Nested(UploadFileSchema()), load_default=[])
+    added = fields.List(
+        fields.Nested(UploadFileSchema()), load_default=[], dump_default=[]
+    )
+    updated = fields.List(
+        fields.Nested(UploadFileSchema()), load_default=[], dump_default=[]
+    )
+    removed = fields.List(
+        fields.Nested(UploadFileSchema()), load_default=[], dump_default=[]
+    )
+    is_blocking = fields.Method("_is_blocking")
 
     class Meta:
         unknown = EXCLUDE
 
-    @post_load
-    def create_obj(self, data, **kwargs):
-        return UploadChanges(**data)
+    def _is_blocking(self, obj) -> bool:
+        """Check if changes would be blocking."""
+        # let's mark upload as non-blocking only if there are new non-spatial data added (e.g. photos)
+        return bool(
+            len(obj.get("updated", []))
+            or len(obj.get("removed", []))
+            or any(
+                is_qgis(f["path"]) or is_versioned_file(f["path"])
+                for f in obj.get("added", [])
+            )
+        )
+
+    @post_dump
+    def remove_blacklisted_files(self, data, **kwargs):
+        """Files which are blacklisted are not allowed to be uploaded and are simple ignored."""
+        for key in ("added", "updated", "removed"):
+            data[key] = [
+                f
+                for f in data[key]
+                if not is_file_name_blacklisted(
+                    f["path"], current_app.config["BLACKLIST"]
+                )
+            ]
+        return data
+
+    @validates_schema
+    def validate(self, data, **kwargs):
+        """Basic consistency validations for upload metadata"""
+        changes_files = [
+            f["path"] for f in data["added"] + data["updated"] + data["removed"]
+        ]
+
+        if len(changes_files) == 0:
+            raise ValidationError("No changes")
+
+        # changes' files must be unique
+        if len(set(changes_files)) != len(changes_files):
+            raise ValidationError("Not unique changes")
+
+        # check if all .gpkg file are valid
+        for file in data["added"] + data["updated"]:
+            if is_versioned_file(file["path"]) and file["size"] == 0:
+                raise ValidationError("File is not valid")
 
 
 class ProjectFileSchema(FileSchema):

--- a/server/mergin/sync/schemas.py
+++ b/server/mergin/sync/schemas.py
@@ -75,7 +75,7 @@ def project_user_permissions(project):
 
 class FileHistorySchema(ma.SQLAlchemyAutoSchema):
     mtime = DateTimeWithZ()
-    diff = fields.Nested(FileSchema(), attribute="diff_file", exclude=("location",))
+    diff = fields.Nested(FileSchema(), attribute="diff_file")
     expiration = DateTimeWithZ(attribute="expiration", dump_only=True)
 
     class Meta:

--- a/server/mergin/sync/storages/disk.py
+++ b/server/mergin/sync/storages/disk.py
@@ -21,7 +21,7 @@ from ..utils import (
     generate_checksum,
     is_versioned_file,
 )
-from ..files import mergin_secure_filename, ProjectFile, UploadFile, File
+from ..files import ProjectDiffFile, mergin_secure_filename, ProjectFile
 
 
 def save_to_file(stream, path, max_size=None):
@@ -245,7 +245,7 @@ class DiskStorage(ProjectStorage):
         return _generator()
 
     def apply_diff(
-        self, current_file: ProjectFile, upload_file: UploadFile, version: int
+        self, current_file: ProjectFile, upload_file: ProjectFile, version: int
     ) -> Result:
         """Apply geodiff diff file on current gpkg basefile. Creates GeodiffActionHistory record of the action.
         Returns checksum and size of generated file. If action fails it returns geodiff error message.
@@ -313,7 +313,7 @@ class DiskStorage(ProjectStorage):
                 return Err(self.gediff_log.getvalue())
 
     def construct_diff(
-        self, current_file: ProjectFile, upload_file: UploadFile, version: int
+        self, current_file: ProjectFile, upload_file: ProjectFile, version: int
     ) -> Result:
         """Construct geodiff diff file from uploaded gpkg and current basefile. Returns diff metadata as a result.
         If action fails it returns geodiff error message.
@@ -345,7 +345,7 @@ class DiskStorage(ProjectStorage):
                     basefile_tmp, uploaded_file_tmp, changeset_tmp
                 )
                 # create diff metadata as it would be created by other clients
-                diff_file = File(
+                diff_file = ProjectDiffFile(
                     path=diff_name,
                     checksum=generate_checksum(changeset_tmp),
                     size=os.path.getsize(changeset_tmp),

--- a/server/mergin/tests/fixtures.py
+++ b/server/mergin/tests/fixtures.py
@@ -19,7 +19,7 @@ from ..stats.app import register
 from ..stats.models import MerginInfo
 from . import test_project, test_workspace_id, test_project_dir, TMP_DIR
 from .utils import login_as_admin, initialize, cleanup, file_info
-from ..sync.files import ChangesSchema
+from ..sync.files import files_changes_from_upload
 
 thisdir = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(thisdir, os.pardir))
@@ -213,12 +213,13 @@ def diff_project(app):
             else:
                 # no files uploaded, hence no action needed
                 pass
-            upload_changes = ChangesSchema(context={"version": i + 2}).load(change)
+
+            file_changes = files_changes_from_upload(change, version=i + 2)
             pv = ProjectVersion(
                 project,
                 i + 2,
                 project.creator.id,
-                upload_changes,
+                file_changes,
                 "127.0.0.1",
             )
             assert pv.project_size == sum(file.size for file in pv.files)

--- a/server/mergin/tests/test_db_hooks.py
+++ b/server/mergin/tests/test_db_hooks.py
@@ -18,7 +18,6 @@ from ..sync.models import (
     ProjectRole,
     ProjectUser,
 )
-from ..sync.files import UploadChanges
 from ..auth.models import User
 from ..app import db
 from . import DEFAULT_USER
@@ -40,8 +39,7 @@ def test_close_user_account(client, diff_project):
     # user has access to mergin user diff_project
     diff_project.set_role(user.id, ProjectRole.WRITER)
     # user contributed to another user project so he is listed in projects history
-    changes = UploadChanges(added=[], updated=[], removed=[])
-    pv = ProjectVersion(diff_project, 11, user.id, changes, "127.0.0.1")
+    pv = ProjectVersion(diff_project, 11, user.id, [], "127.0.0.1")
     diff_project.latest_version = pv.name
     pv.project = diff_project
     db.session.add(pv)
@@ -116,8 +114,9 @@ def test_remove_project(client, diff_project):
     # set up
     mergin_user = User.query.filter_by(username=DEFAULT_USER[0]).first()
     project_dir = Path(diff_project.storage.project_dir)
-    changes = UploadChanges(added=[], removed=[], updated=[])
-    upload = Upload(diff_project, changes, mergin_user.id)
+    upload = Upload(
+        diff_project, {"added": [], "removed": [], "updated": []}, mergin_user.id
+    )
     db.session.add(upload)
     project_id = diff_project.id
     user = add_user("user", "user")

--- a/server/mergin/tests/utils.py
+++ b/server/mergin/tests/utils.py
@@ -20,7 +20,7 @@ from pygeodiff import GeoDiff
 from ..auth.models import User, UserProfile
 from ..sync.utils import generate_location, generate_checksum
 from ..sync.models import Project, ProjectVersion, FileHistory, ProjectRole
-from ..sync.files import UploadChanges, ChangesSchema
+from ..sync.files import ProjectFileChange, PushChangeType, files_changes_from_upload
 from ..sync.workspace import GlobalWorkspace
 from ..app import db
 from . import json_headers, DEFAULT_USER, test_project, test_project_dir, TMP_DIR
@@ -82,8 +82,7 @@ def create_project(name, workspace, user, **kwargs):
     p.updated = datetime.utcnow()
     db.session.add(p)
     db.session.flush()
-    changes = UploadChanges(added=[], updated=[], removed=[])
-    pv = ProjectVersion(p, 0, user.id, changes, "127.0.0.1")
+    pv = ProjectVersion(p, 0, user.id, [], "127.0.0.1")
     db.session.add(pv)
     db.session.commit()
 
@@ -156,15 +155,17 @@ def initialize():
         for f in files:
             abs_path = os.path.join(root, f)
             project_files.append(
-                {
-                    "path": abs_path.replace(test_project_dir, "").lstrip("/"),
-                    "location": os.path.join(
+                ProjectFileChange(
+                    path=abs_path.replace(test_project_dir, "").lstrip("/"),
+                    checksum=generate_checksum(abs_path),
+                    size=os.path.getsize(abs_path),
+                    mtime=str(datetime.fromtimestamp(os.path.getmtime(abs_path))),
+                    change=PushChangeType.CREATE,
+                    location=os.path.join(
                         "v1", abs_path.replace(test_project_dir, "").lstrip("/")
                     ),
-                    "size": os.path.getsize(abs_path),
-                    "checksum": generate_checksum(abs_path),
-                    "mtime": str(datetime.fromtimestamp(os.path.getmtime(abs_path))),
-                }
+                    diff=None,
+                )
             )
     p.latest_version = 1
     p.public = True
@@ -173,14 +174,7 @@ def initialize():
     db.session.add(p)
     db.session.commit()
 
-    upload_changes = ChangesSchema(context={"version": 1}).load(
-        {
-            "added": project_files,
-            "updated": [],
-            "removed": [],
-        }
-    )
-    pv = ProjectVersion(p, 1, user.id, upload_changes, "127.0.0.1")
+    pv = ProjectVersion(p, 1, user.id, project_files, "127.0.0.1")
     db.session.add(pv)
     db.session.commit()
 
@@ -285,7 +279,7 @@ def create_blank_version(project):
         project,
         project.next_version(),
         project.creator.id,
-        UploadChanges(added=[], updated=[], removed=[]),
+        [],
         "127.0.0.1",
     )
     db.session.add(pv)
@@ -355,14 +349,12 @@ def push_change(project, action, path, src_dir):
     else:
         return
 
-    upload_changes = ChangesSchema(context={"version": project.next_version()}).load(
-        changes
-    )
+    file_changes = files_changes_from_upload(changes, version=project.next_version())
     pv = ProjectVersion(
         project,
         project.next_version(),
         project.creator.id,
-        upload_changes,
+        file_changes,
         "127.0.0.1",
     )
     db.session.add(pv)


### PR DESCRIPTION
- move relevant validations into upload schema
- use upload schema only in push init while project file object is used for actual file manipulations 
- remove version context and redundant dataclasses for upload schema