### PR TITLE
Custom bearer token expiration validation

### DIFF
--- a/server/mergin/app.py
+++ b/server/mergin/app.py
@@ -209,7 +209,6 @@ def create_app(public_keys: List[str] = None) -> Flask:
                     app.app.config["SECRET_KEY"],
                     app.app.config["SECURITY_BEARER_SALT"],
                     header_val,
-                    app.app.config["BEARER_TOKEN_EXPIRATION"],
                 )
                 user = User.query.filter_by(
                     id=data["user_id"], username=data["username"], email=data["email"]

--- a/server/mergin/auth/bearer.py
+++ b/server/mergin/auth/bearer.py
@@ -3,17 +3,28 @@
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 
 import hashlib
+from datetime import datetime, timezone
 from itsdangerous import URLSafeTimedSerializer
+from itsdangerous.exc import SignatureExpired, BadSignature
 from flask.sessions import TaggedJSONSerializer
 
 
-def decode_token(secret_key, salt, token, max_age=None):
+def decode_token(secret_key, salt, token):
     serializer = TaggedJSONSerializer()
     signer_kwargs = {"key_derivation": "hmac", "digest_method": hashlib.sha1}
     s = URLSafeTimedSerializer(
         secret_key, salt=salt, serializer=serializer, signer_kwargs=signer_kwargs
     )
-    return s.loads(token, max_age=max_age)
+    token_data = s.loads(token)
+    try:
+        expire = datetime.fromisoformat(token_data.get("expire"))
+    except (ValueError, TypeError):
+        raise BadSignature("Invalid token")
+
+    if expire < datetime.now(timezone.utc):
+        raise SignatureExpired("Token expired")
+
+    return token_data
 
 
 def encode_token(secret_key, salt, data):


### PR DESCRIPTION
Previously we validated all access tokens with the same expiration value but since SSO we have two types of access token with different expiration period. Therefore, we use `expire` field to validate if token is still valid (instead of built-in max_age validation).