### PR TITLE
Fix push finish on racing conditions

### DIFF
--- a/server/mergin/sync/files.py
+++ b/server/mergin/sync/files.py
@@ -80,17 +80,18 @@ class ProjectFileChange(ProjectFile):
     change: PushChangeType
 
 
-def files_changes_from_upload(changes: dict, version: int) -> List["ProjectFileChange"]:
+def files_changes_from_upload(
+    changes: dict, location_dir: str
+) -> List["ProjectFileChange"]:
     """Create a list of version file changes from upload changes dictionary used by public API.
 
     It flattens changes dict and adds change type to each item. Also generates location for each file.
     """
     secure_filenames = []
     version_changes = []
-    version = "v" + str(version)
     for key in ("added", "updated", "removed"):
         for item in changes.get(key, []):
-            location = os.path.join(version, mergin_secure_filename(item["path"]))
+            location = os.path.join(location_dir, mergin_secure_filename(item["path"]))
             diff = None
 
             # make sure we have unique location for each file
@@ -110,7 +111,7 @@ def files_changes_from_upload(changes: dict, version: int) -> List["ProjectFileC
                 if item.get("diff"):
                     change = PushChangeType.UPDATE_DIFF
                     diff_location = os.path.join(
-                        version, mergin_secure_filename(item["diff"]["path"])
+                        location_dir, mergin_secure_filename(item["diff"]["path"])
                     )
                     if diff_location in secure_filenames:
                         filename, file_extension = os.path.splitext(diff_location)

--- a/server/mergin/sync/models.py
+++ b/server/mergin/sync/models.py
@@ -315,6 +315,13 @@ class Project(db.Model):
 
         return set(id_diffs)
 
+    def version_exists(self, version: int) -> bool:
+        """Check if particular project version exists"""
+        return bool(
+            os.path.exists(os.path.join(self.storage.project_dir, f"v{version}"))
+            or ProjectVersion.query.filter_by(project_id=self.id, name=version).count()
+        )
+
 
 class ProjectRole(Enum):
     """Project roles ordered by rank (do not change)"""

--- a/server/mergin/sync/models.py
+++ b/server/mergin/sync/models.py
@@ -315,13 +315,6 @@ class Project(db.Model):
 
         return set(id_diffs)
 
-    def version_exists(self, version: int) -> bool:
-        """Check if particular project version exists"""
-        return bool(
-            os.path.exists(os.path.join(self.storage.project_dir, f"v{version}"))
-            or ProjectVersion.query.filter_by(project_id=self.id, name=version).count()
-        )
-
 
 class ProjectRole(Enum):
     """Project roles ordered by rank (do not change)"""

--- a/server/mergin/sync/storages/disk.py
+++ b/server/mergin/sync/storages/disk.py
@@ -245,7 +245,7 @@ class DiskStorage(ProjectStorage):
         return _generator()
 
     def apply_diff(
-        self, current_file: ProjectFile, upload_file: ProjectFile, version: int
+        self, current_file: ProjectFile, changeset: str, patchedfile: str, version: int
     ) -> Result:
         """Apply geodiff diff file on current gpkg basefile. Creates GeodiffActionHistory record of the action.
         Returns checksum and size of generated file. If action fails it returns geodiff error message.
@@ -254,8 +254,6 @@ class DiskStorage(ProjectStorage):
 
         v_name = ProjectVersion.to_v_name(version)
         basefile = os.path.join(self.project_dir, current_file.location)
-        changeset = os.path.join(self.project_dir, upload_file.diff.location)
-        patchedfile = os.path.join(self.project_dir, upload_file.location)
         # create local copy of basefile which will be updated in next version and changeset needed
         # TODO this can potentially fail for large files
         logging.info(f"Apply changes: copying {basefile} to {patchedfile}")
@@ -313,7 +311,11 @@ class DiskStorage(ProjectStorage):
                 return Err(self.gediff_log.getvalue())
 
     def construct_diff(
-        self, current_file: ProjectFile, upload_file: ProjectFile, version: int
+        self,
+        current_file: ProjectFile,
+        changeset: str,
+        uploaded_file: str,
+        version: int,
     ) -> Result:
         """Construct geodiff diff file from uploaded gpkg and current basefile. Returns diff metadata as a result.
         If action fails it returns geodiff error message.
@@ -322,19 +324,14 @@ class DiskStorage(ProjectStorage):
 
         v_name = ProjectVersion.to_v_name(version)
         basefile = os.path.join(self.project_dir, current_file.location)
-        uploaded_file = os.path.join(self.project_dir, upload_file.location)
-        diff_name = upload_file.path + "-diff-" + str(uuid.uuid4())
-        changeset = os.path.join(self.project_dir, v_name, diff_name)
+        diff_name = os.path.basename(changeset)
         with self.geodiff_copy(basefile) as basefile_tmp, self.geodiff_copy(
             uploaded_file
         ) as uploaded_file_tmp:
             try:
                 # create changeset next to uploaded file copy
                 changeset_tmp = os.path.join(
-                    uploaded_file_tmp.replace(upload_file.location, "").rstrip(
-                        os.path.sep
-                    ),
-                    v_name,
+                    os.path.dirname(uploaded_file_tmp),
                     diff_name,
                 )
                 self.flush_geodiff_logger()
@@ -349,7 +346,7 @@ class DiskStorage(ProjectStorage):
                     path=diff_name,
                     checksum=generate_checksum(changeset_tmp),
                     size=os.path.getsize(changeset_tmp),
-                    location=os.path.join(v_name, mergin_secure_filename(diff_name)),
+                    location=os.path.join(v_name, diff_name),
                 )
                 copy_file(changeset_tmp, changeset)
                 return Ok(diff_file)

--- a/server/mergin/sync/storages/disk.py
+++ b/server/mergin/sync/storages/disk.py
@@ -245,14 +245,14 @@ class DiskStorage(ProjectStorage):
         return _generator()
 
     def apply_diff(
-        self, current_file: ProjectFile, changeset: str, patchedfile: str, version: int
+        self, current_file: ProjectFile, changeset: str, patchedfile: str
     ) -> Result:
         """Apply geodiff diff file on current gpkg basefile. Creates GeodiffActionHistory record of the action.
         Returns checksum and size of generated file. If action fails it returns geodiff error message.
         """
         from ..models import GeodiffActionHistory, ProjectVersion
 
-        v_name = ProjectVersion.to_v_name(version)
+        v_name = ProjectVersion.to_v_name(self.project.next_version())
         basefile = os.path.join(self.project_dir, current_file.location)
         # create local copy of basefile which will be updated in next version and changeset needed
         # TODO this can potentially fail for large files
@@ -315,14 +315,10 @@ class DiskStorage(ProjectStorage):
         current_file: ProjectFile,
         changeset: str,
         uploaded_file: str,
-        version: int,
     ) -> Result:
         """Construct geodiff diff file from uploaded gpkg and current basefile. Returns diff metadata as a result.
         If action fails it returns geodiff error message.
         """
-        from ..models import ProjectVersion
-
-        v_name = ProjectVersion.to_v_name(version)
         basefile = os.path.join(self.project_dir, current_file.location)
         diff_name = os.path.basename(changeset)
         with self.geodiff_copy(basefile) as basefile_tmp, self.geodiff_copy(
@@ -341,15 +337,13 @@ class DiskStorage(ProjectStorage):
                 self.geodiff.create_changeset(
                     basefile_tmp, uploaded_file_tmp, changeset_tmp
                 )
-                # create diff metadata as it would be created by other clients
-                diff_file = ProjectDiffFile(
-                    path=diff_name,
-                    checksum=generate_checksum(changeset_tmp),
-                    size=os.path.getsize(changeset_tmp),
-                    location=os.path.join(v_name, diff_name),
-                )
                 copy_file(changeset_tmp, changeset)
-                return Ok(diff_file)
+                return Ok(
+                    (
+                        generate_checksum(changeset_tmp),
+                        os.path.getsize(changeset_tmp),
+                    )
+                )
             except (GeoDiffLibError, GeoDiffLibConflictError) as e:
                 # diff is not possible to create - file will be overwritten
                 move_to_tmp(changeset)

--- a/server/mergin/tests/fixtures.py
+++ b/server/mergin/tests/fixtures.py
@@ -214,7 +214,7 @@ def diff_project(app):
                 # no files uploaded, hence no action needed
                 pass
 
-            file_changes = files_changes_from_upload(change, version=i + 2)
+            file_changes = files_changes_from_upload(change, location_dir=f"v{i + 2}")
             pv = ProjectVersion(
                 project,
                 i + 2,

--- a/server/mergin/tests/test_project_controller.py
+++ b/server/mergin/tests/test_project_controller.py
@@ -38,7 +38,7 @@ from ..sync.models import (
     PushChangeType,
     ProjectFilePath,
 )
-from ..sync.files import ChangesSchema, files_changes_from_upload
+from ..sync.files import files_changes_from_upload
 from ..sync.schemas import ProjectListSchema
 from ..sync.utils import generate_checksum, is_versioned_file, get_project_path
 from ..auth.models import User, UserProfile
@@ -1501,12 +1501,7 @@ def test_push_finish(client):
 
     # test finish upload when another upload was already processed
     original_version = upload.project.latest_version
-    with patch(
-        "mergin.sync.models.Project.version_exists"
-    ) as mock_version_exists, patch(
-        "mergin.sync.models.Project.next_version"
-    ) as mock_next_version:
-        mock_version_exists.return_value = True
+    with patch("mergin.sync.models.Project.next_version") as mock_next_version:
         mock_next_version.return_value = original_version + 2
 
         resp = client.post(
@@ -2422,7 +2417,7 @@ def add_project_version(project, changes, version=None):
         else User.query.filter_by(username=DEFAULT_USER[0]).first()
     )
     next_version = version or project.next_version()
-    file_changes = files_changes_from_upload(changes, version=next_version)
+    file_changes = files_changes_from_upload(changes, location_dir="v{next_version}")
     pv = ProjectVersion(
         project,
         next_version,

--- a/server/mergin/tests/test_project_controller.py
+++ b/server/mergin/tests/test_project_controller.py
@@ -1499,38 +1499,31 @@ def test_push_finish(client):
                 with open(os.path.join(upload_dir, "chunks", chunk), "wb") as out_file:
                     out_file.write(in_file.read(CHUNK_SIZE))
 
-    # test finish upload, pretend another upload is already being processed
-    os.makedirs(
-        os.path.join(
-            upload.project.storage.project_dir, f"v{upload.project.latest_version + 1}"
-        ),
-        exist_ok=True,
-    )
-    resp = client.post(
-        url,
-        headers=json_headers,
-    )
-    assert resp.status_code == 409
-    # bump to fake version to make upload finish pass
-    upload.project.latest_version += 1
-    db.session.add(upload.project)
-    pv = ProjectVersion(
-        upload.project,
-        upload.project.latest_version,
-        upload.project.creator.id,
-        [],
-        "127.0.0.1",
-    )
-    pv.project = upload.project
-    db.session.add(pv)
-    db.session.commit()
+    # test finish upload when another upload was already processed
+    original_version = upload.project.latest_version
+    with patch(
+        "mergin.sync.models.Project.version_exists"
+    ) as mock_version_exists, patch(
+        "mergin.sync.models.Project.next_version"
+    ) as mock_next_version:
+        mock_version_exists.return_value = True
+        mock_next_version.return_value = original_version + 2
 
-    resp2 = client.post(url, headers={**json_headers, "User-Agent": "Werkzeug"})
-    assert resp2.status_code == 200
-    assert not os.path.exists(upload_dir)
-    version = upload.project.get_latest_version()
-    assert version.user_agent
-    assert version.device_id == json_headers["X-Device-Id"]
+        resp = client.post(
+            url,
+            headers=json_headers,
+        )
+
+        assert resp.status_code == 200
+        project = Project.query.get(upload.project.id)
+        version = project.get_latest_version()
+        # finish created higher version than origially expected
+        assert version.name == mock_next_version.return_value
+        assert os.path.exists(
+            os.path.join(upload.project.storage.project_dir, f"v{version.name}")
+        )
+        assert version.user_agent
+        assert version.device_id == json_headers["X-Device-Id"]
 
     # tests basic failures
     resp3 = client.post("/v1/project/push/finish/not-existing")
@@ -1557,7 +1550,7 @@ def test_push_finish(client):
     assert resp4.status_code == 403
 
     # other failures with error code 403, 404 does to count to failures history
-    assert SyncFailuresHistory.query.count() == 2
+    assert SyncFailuresHistory.query.count() == 1
 
 
 def test_push_close(client):

--- a/server/mergin/tests/utils.py
+++ b/server/mergin/tests/utils.py
@@ -349,7 +349,9 @@ def push_change(project, action, path, src_dir):
     else:
         return
 
-    file_changes = files_changes_from_upload(changes, version=project.next_version())
+    file_changes = files_changes_from_upload(
+        changes, location_dir=f"v{project.next_version()}"
+    )
     pv = ProjectVersion(
         project,
         project.next_version(),


### PR DESCRIPTION
Server determines the next version on push finish just before moving files which were already prepared (including geodiff acttions). This should address the issue when during push finish another version is already created.

Workflow in push finish is changed that all hard work is done **before** final version check.

Example:
- on push finish server is currently on v4
- during chunks merge someone else created v5 version
- before commit to db server would bump to v6 for current push finish and move already created files to correct destination