### PR TITLE
Adjust avatar font size globally

### DIFF
--- a/web-app/packages/admin-lib/src/modules/admin/views/AccountDetailView.vue
+++ b/web-app/packages/admin-lib/src/modules/admin/views/AccountDetailView.vue
@@ -14,14 +14,11 @@
           <PAvatar
             v-if="user"
             :label="$filters.getAvatar(user?.email, user?.username)"
+            size="xlarge"
             shape="circle"
             :pt="{
               root: {
-                class: 'text-5xl font-semibold text-color-forest',
-                style: {
-                  width: '120px',
-                  height: '120px'
-                }
+                class: 'font-semibold text-color-forest'
               }
             }"
           />

--- a/web-app/packages/lib/src/assets/sass/theme-base/components/misc/_avatar.scss
+++ b/web-app/packages/lib/src/assets/sass/theme-base/components/misc/_avatar.scss
@@ -1,6 +1,7 @@
 .p-avatar {
     background-color: $avatarBg;
     border-radius: $borderRadius;
+    font-size: $avatarFontSize !important;
 
     &.p-avatar-lg {
         width: 3rem;

--- a/web-app/packages/lib/src/assets/sass/theme-base/components/misc/_avatar.scss
+++ b/web-app/packages/lib/src/assets/sass/theme-base/components/misc/_avatar.scss
@@ -1,3 +1,4 @@
+// widths, heights and font-sizes are updated with custom values from our Figma design
 .p-avatar {
     background-color: $avatarBg;
     border-radius: $borderRadius;

--- a/web-app/packages/lib/src/assets/sass/theme-base/components/misc/_avatar.scss
+++ b/web-app/packages/lib/src/assets/sass/theme-base/components/misc/_avatar.scss
@@ -1,25 +1,24 @@
 .p-avatar {
     background-color: $avatarBg;
     border-radius: $borderRadius;
-    font-size: $avatarFontSize !important;
 
     &.p-avatar-lg {
-        width: 3rem;
-        height: 3rem;
-        font-size: 1.5rem;
+        width: 2.625rem;
+        height: 2.625rem;
+        font-size: 1.125rem;
 
         .p-avatar-icon {
-            font-size: 1.5rem;
+            font-size: 1.125rem;
         }
     }
 
     &.p-avatar-xl {
-        width: 4rem;
-        height: 4rem;
-        font-size: 2rem;
+        width: 7.5rem;
+        height: 7.5rem;
+        font-size: 3.214rem;
 
         .p-avatar-icon {
-            font-size: 2rem;
+            font-size: 3.214rem;
         }
     }
 }

--- a/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/_extensions.scss
+++ b/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/_extensions.scss
@@ -119,3 +119,8 @@ img {
   color: map-get($map: $colors, $key: grape);
   font-weight: 600;
 }
+
+// Font size in avatar
+.p-avatar:not(.p-avatar-lg):not(.p-avatar-xl) {
+  font-size: 0.857rem;
+}

--- a/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/variables/_misc.scss
+++ b/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/variables/_misc.scss
@@ -82,11 +82,6 @@ $progressSpinnerColorFour:$warningMessageTextColor !default;
 /// @group misc
 $avatarBg: map-get($map: $colors, $key: medium-green);
 
-/// Avatar font size
-/// @group misc
-$avatarFontSize: 0.857rem;
-
-
 /// Text color of an avatar
 /// @group misc
 $avatarTextColor:$textColor;

--- a/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/variables/_misc.scss
+++ b/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/variables/_misc.scss
@@ -82,6 +82,11 @@ $progressSpinnerColorFour:$warningMessageTextColor !default;
 /// @group misc
 $avatarBg: map-get($map: $colors, $key: medium-green);
 
+/// Avatar font size
+/// @group misc
+$avatarFontSize: 0.857rem;
+
+
 /// Text color of an avatar
 /// @group misc
 $avatarTextColor:$textColor;

--- a/web-app/packages/lib/src/modules/user/views/ProfileViewTemplate.vue
+++ b/web-app/packages/lib/src/modules/user/views/ProfileViewTemplate.vue
@@ -61,13 +61,10 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
           <PAvatar
             :label="$filters.getAvatar(loggedUser.email, loggedUser.name)"
             shape="circle"
+            size="xlarge"
             :pt="{
               root: {
-                class: 'text-5xl font-semibold text-color-forest',
-                style: {
-                  width: '120px',
-                  height: '120px'
-                }
+                class: 'font-semibold text-color-forest'
               }
             }"
           />


### PR DESCRIPTION
Fixes https://github.com/MerginMaps/server-private/issues/3041

Adjust avatar font sizes to align with Figma design

<img width="927" height="556" alt="image" src="https://github.com/user-attachments/assets/151cba5b-f0b4-404f-ba86-6ae3fb6676ec" />

propagates correctly to members page:

<img width="1609" height="739" alt="image" src="https://github.com/user-attachments/assets/86c95275-d1ec-4211-9c3e-85d98a6718c2" />
