### PR TITLE
Remove upload chunks only if push was successful

### DIFF
--- a/server/mergin/sync/models.py
+++ b/server/mergin/sync/models.py
@@ -1092,7 +1092,6 @@ class Upload(db.Model):
                                     dest.write(data)
                                     data = src.read(8192)
 
-                            move_to_tmp(chunk_file)
                     except IOError:
                         logging.exception(
                             f"Failed to process chunk: {chunk_id} in project {project_path}"

--- a/server/mergin/sync/public_api_controller.py
+++ b/server/mergin/sync/public_api_controller.py
@@ -1032,6 +1032,15 @@ def push_finish(transaction_id):
 
         # let's move uploaded files where they are expected to be
         os.renames(files_dir, version_dir)
+
+        # remove used chunks
+        for file in upload.changes["added"] + upload.changes["updated"]:
+            file_chunks = file.get("chunks", [])
+            for chunk_id in file_chunks:
+                chunk_file = os.path.join(upload.upload_dir, "chunks", chunk_id)
+                if os.path.exists(chunk_file):
+                    move_to_tmp(chunk_file)
+
         logging.info(
             f"Push finished for project: {project.id}, project version: {v_next_version}, transaction id: {transaction_id}."
         )

--- a/server/mergin/sync/public_api_v2_controller.py
+++ b/server/mergin/sync/public_api_v2_controller.py
@@ -295,6 +295,14 @@ def create_project_version(id):
             temp_files_dir = os.path.join(upload.upload_dir, "files", v_next_version)
             os.renames(temp_files_dir, version_dir)
 
+            # remove used chunks
+            for file in to_be_added_files + to_be_updated_files:
+                file_chunks = file.get("chunks", [])
+                for chunk_id in file_chunks:
+                    chunk_file = get_chunk_location(chunk_id)
+                    if os.path.exists(chunk_file):
+                        move_to_tmp(chunk_file)
+
         logging.info(
             f"Push finished for project: {project.id}, project version: {v_next_version}, upload id: {upload.id}."
         )


### PR DESCRIPTION
Remove uploaded chunks not after they were used but only if whole push transaction was successful.

Fix the issue if client (v2) wants to reuse uploaded chunks after some failure. It also solves the issue of one chunk being used for more than one file (kind of edge case of the same file with different names).