### PR TITLE
Cache last sign in date in User table

### DIFF
--- a/server/migrations/community/b9ec9ab6694f_add_user_last_signed_in.py
+++ b/server/migrations/community/b9ec9ab6694f_add_user_last_signed_in.py
@@ -1,0 +1,25 @@
+"""Add user last signed in
+
+Revision ID: b9ec9ab6694f
+Revises: 6cb54659c1de
+Create Date: 2025-09-09 15:43:19.554498
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "b9ec9ab6694f"
+down_revision = "6cb54659c1de"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("user", sa.Column("last_signed_in", sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("user", "last_signed_in")


### PR DESCRIPTION
We want to have user's last successful sign in date available in User table so it is quickly accessible by APIs. We update the value at user login. Also there is a fallback option to calculate login dates from LoginHistory and cache the result.

In DB migration we only add new column and leave data to be updated on demand.