### PR TITLE
Filter diff files from mimetype testing in push finish

### DIFF
--- a/server/mergin/sync/public_api_controller.py
+++ b/server/mergin/sync/public_api_controller.py
@@ -1021,7 +1021,7 @@ def push_finish(transaction_id):
                 )
                 corrupted_files.append(f.path)
                 continue
-        if not is_supported_type(dest_file):
+        if not f.diff and not is_supported_type(dest_file):
             logging.info(f"Rejecting blacklisted file: {dest_file}")
             abort(
                 400,


### PR DESCRIPTION
Resolved https://github.com/MerginMaps/server-private/issues/3092

- geodiff manipulation will validate such diffs