### PR TITLE
add valid mimetype for .py files

### DIFF
--- a/server/mergin/sync/utils.py
+++ b/server/mergin/sync/utils.py
@@ -535,6 +535,7 @@ FORBIDDEN_MIME_TYPES = {
     "application/x-ms-application",
     "application/x-ms-wim",
     "text/x-shellscript",
+    "text/x-script.python",
 }
 
 


### PR DESCRIPTION
- we are validating .py files by extension -> validate also mime type for such a files