### PR TITLE
API: add 'v' prefix to version in delta endpoint

### DIFF
--- a/server/mergin/sync/files.py
+++ b/server/mergin/sync/files.py
@@ -334,6 +334,7 @@ class DeltaChangeSchema(DeltaChangeBaseSchema):
 class DeltaChangeItemSchema(DeltaChangeBaseSchema):
     """Schema for delta changes response"""
 
+    version = fields.Function(lambda obj: f"v{obj.version}")
     diffs = fields.List(fields.Nested(DeltaChangeDiffFileSchema()))
 
     @post_dump

--- a/server/mergin/sync/public_api_v2.yaml
+++ b/server/mergin/sync/public_api_v2.yaml
@@ -393,16 +393,12 @@ paths:
           in: query
           required: true
           schema:
-            type: integer
-            example:
-            minimum: 0
+            $ref: "#/components/schemas/VersionName"
           description: Start version (exclusive)
         - name: to
           in: query
           schema:
-            type: integer
-            example: 2
-            minimum: 1
+            $ref: "#/components/schemas/VersionName"
           description: End version (inclusive)
       responses:
         "200":
@@ -858,8 +854,7 @@ components:
           type: string
           example: 9adb76bf81a34880209040ffe5ee262a090b62ab
         version:
-          type: integer
-          example: 1
+          $ref: "#/components/schemas/VersionName"
         change:
           $ref: "#/components/schemas/ProjectChangeType"
         diffs:
@@ -880,3 +875,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ProjectDeltaChange"
+    VersionName:
+      type: string
+      pattern: '^v\d+$'
+      example: v2

--- a/server/mergin/sync/public_api_v2_controller.py
+++ b/server/mergin/sync/public_api_v2_controller.py
@@ -405,11 +405,18 @@ def upload_chunk(id: str):
     )
 
 
-def get_project_delta(id: str, since: int, to: Optional[int] = None):
+def get_project_delta(id: str, since: str, to: Optional[str] = None):
     """Get project changes (delta) between two versions"""
 
     project: Project = require_project_by_uuid(id, ProjectPermissions.Read)
-    to = project.latest_version if to is None else to
+    since = ProjectVersion.from_v_name(since)
+    to = project.latest_version if to is None else ProjectVersion.from_v_name(to)
+    if since < 0 or to < 1:
+        abort(
+            400,
+            "Invalid version number, minimum version for 'since' is 0 and minimum version for 'to' is 1",
+        )
+
     if to > project.latest_version:
         abort(400, "'to' version exceeds latest project version")
 


### PR DESCRIPTION
We want to make new `v2/` consistent and keep using `v` prefix in api request / response. Internally we still use integers but clients would keep using old naming.