### PR TITLE
Update docker images for EE to use dockerhub registry

### DIFF
--- a/deployment/enterprise/README.md
+++ b/deployment/enterprise/README.md
@@ -3,22 +3,17 @@
 Suitable for Ubuntu servers, single-node deployment using Docker Compose and system NGINX as a reverse proxy.
 
 > [!IMPORTANT]
-> Docker images for Mergin Maps Enterprise Edition are stored in a private AWS ECR repository.
+> Docker images for Mergin Maps Enterprise Edition are stored in private Dockerhub repositories.
 > To access them, you need a Mergin Maps Enterprise [subscription](https://merginmaps.com/pricing).
 > Please contact the Mergin Maps [sales team](https://merginmaps.com/contact-sales)!
 
-## Login to Mergin Maps AWS ECR Repository
-
-```shell
-aws ecr --region eu-west-1 get-login-password | docker login --username AWS --password-stdin 433835555346.dkr.ecr.eu-west-1.amazonaws.com
-```
-
 ## Load Docker Images, Configure, and Run Mergin Maps Stack
 
-To run Mergin Maps, you need to load local Docker images (if any). Make sure you have access to Lutra's ECR repository. You can check this by running:
+Login to dockerhub (you should have already received your access token from Mergin Maps team).
+To run Mergin Maps, you need to load local Docker images (if any). Make sure you have access to Lutra's repositories. You can check this by running:
 
 ```shell
-docker pull 433835555346.dkr.ecr.eu-west-1.amazonaws.com/mergin/mergin-ee-back:2025.3.0
+docker pull lutraconsulting/merginmaps-backend-ee:2025.7.3
 ```
 
 Then modify the [docker-compose file](docker-compose.yml) and create the environment file `.prod.env` from `.env.template`. Details about configuration can be found in the [docs](https://merginmaps.com/docs/server/install/).

--- a/deployment/enterprise/docker-compose.maps.yml
+++ b/deployment/enterprise/docker-compose.maps.yml
@@ -6,7 +6,7 @@ networks:
 services:
   qgis:
     container_name: mergin-qgis
-    image: 433835555346.dkr.ecr.eu-west-1.amazonaws.com/mergin/qgis-server-ee:2025.1.0
+    image: lutraconsulting/qgis-server:2025.1.0
     user: 1000:999
     networks:
       - mergin-net
@@ -30,7 +30,7 @@ services:
       - ./qgis_nginx.conf:/etc/nginx/conf.d/default.conf
   qgis_extractor:
     container_name: mergin-qgis-extractor
-    image: 433835555346.dkr.ecr.eu-west-1.amazonaws.com/mergin/qgis-extractor-ee:2025.3.0
+    image: lutraconsulting/qgis-extractor:2025.3.1
     user: 901:999
     networks:
       - mergin-net

--- a/deployment/enterprise/docker-compose.yml
+++ b/deployment/enterprise/docker-compose.yml
@@ -5,7 +5,7 @@ networks:
 
 services:
   server:
-    image: 433835555346.dkr.ecr.eu-west-1.amazonaws.com/mergin/mergin-ee-back:2025.7.3
+    image: lutraconsulting/merginmaps-backend-ee:2025.7.3
     container_name: merginmaps-server
     restart: always
     user: 901:999
@@ -22,7 +22,7 @@ services:
     networks:
       - mergin
   web:
-    image: 433835555346.dkr.ecr.eu-west-1.amazonaws.com/mergin/mergin-ee-front:2025.7.3
+    image: lutraconsulting/merginmaps-frontend-ee:2025.7.3
     container_name: merginmaps-web
     restart: always
     depends_on:
@@ -52,7 +52,7 @@ services:
       - server
 
   celery-beat:
-    image: 433835555346.dkr.ecr.eu-west-1.amazonaws.com/mergin/mergin-ee-back:2025.7.3
+    image: lutraconsulting/merginmaps-backend-ee:2025.7.3
     container_name: merginmaps-celery-beat
     restart: always
     user: 901:999
@@ -66,7 +66,7 @@ services:
       - mergin
 
   celery-worker:
-    image: 433835555346.dkr.ecr.eu-west-1.amazonaws.com/mergin/mergin-ee-back:2025.7.3
+    image: lutraconsulting/merginmaps-backend-ee:2025.7.3
     container_name: merginmaps-celery-worker
     restart: always
     user: 901:999


### PR DESCRIPTION
As we are migrating from AWS ECR, latest EE images are already available from dockerhub.