### PR TITLE
Upgrade Node.js from 18 to 22 for Vue web applications

### DIFF
--- a/web-app/Dockerfile
+++ b/web-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine as builder
+FROM node:22-alpine as builder
 MAINTAINER Martin Varga "martin.varga@lutraconsulting.co.uk"
 
 # build frontend apps

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -70,7 +70,7 @@
     "vue-tsc": "^2.1.6"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "version": "0.0.0",
   "dependencies": {}


### PR DESCRIPTION
## Summary
Upgrade Node.js version from 18 to 22 for the Vue web applications.

## Changes
- Updated Dockerfile to use `node:22-alpine` base image
- Updated `package.json` engines requirement to `>=22`

## Testing
- `yarn install` completed successfully
- `yarn build:libs` completed successfully

The TypeScript type declaration warnings during build are pre-existing issues not related to this Node.js upgrade.