### PR TITLE
Fix link to local Mergin Maps instance documentation

### DIFF
--- a/LICENSES/CLA-signed-list.md
+++ b/LICENSES/CLA-signed-list.md
@@ -21,3 +21,4 @@ C/ My company has custom contribution contract with Lutra Consulting Ltd. or I a
 * luxusko, 25th August 2023
 * jozef-budac, 30th January 2024
 * fernandinand, 13th March 2025
+* wonder-sk, 9th February 2026

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Try Mergin Maps at https://merginmaps.com/ - the SaaS service run by Lutra Consu
 
 ### Running locally
 
-A step-by-step guide how to run local Mergin Maps instance can be found in our [documentation](https://merginmaps.com/docs/dev/mergince/). 
+A step-by-step guide how to run local Mergin Maps instance can be found in our [documentation](https://merginmaps.com/docs/server/install/). 
 
 ### Manage Mergin Maps
 


### PR DESCRIPTION
The old link would take me to overview of CE/EE rather than the installation page...