### PR TITLE
Update logic for counting editors

### DIFF
--- a/server/mergin/sync/workspace.py
+++ b/server/mergin/sync/workspace.py
@@ -363,17 +363,17 @@ class GlobalWorkspaceHandler(WorkspaceHandler):
 
     def server_editors_count(self) -> int:
         if Configuration.GLOBAL_ADMIN or Configuration.GLOBAL_WRITE:
-            return User.query.filter(
-                is_(User.username.ilike("deleted_%"), False),
-            ).count()
+            return User.query.filter(User.active == True).count()
 
         return (
             db.session.query(ProjectUser.user_id)
             .select_from(Project)
             .join(ProjectUser)
+            .join(User, User.id == ProjectUser.user_id)
             .filter(
                 Project.removed_at.is_(None),
                 ProjectUser.role != ProjectRole.READER.value,
+                User.active == True,
             )
             .group_by(ProjectUser.user_id)
             .count()

--- a/server/mergin/tests/test_workspace.py
+++ b/server/mergin/tests/test_workspace.py
@@ -46,6 +46,12 @@ def test_workspace_implementation(client):
     assert ws.user_has_permissions(user, "write")
     assert ws.user_has_permissions(user, "read")
     assert handler.server_editors_count() == 2
+    # inactive user should not be counted
+    user.active = False
+    db.session.commit()
+    assert handler.server_editors_count() == 1
+    user.active = True
+    db.session.commit()
     assert not ws.user_has_permissions(user, "admin")
     assert not ws.user_has_permissions(user, "owner")
 


### PR DESCRIPTION
Updated query to include only active users so deleted and also deactivated users wont be present. Also changed return query to also return only active users. As per ticket #3233, this behaviour is no longer wanted. No other filtering for invited users was needed as the return query only counts project users. Invited users are not present here. Lastly updated tests to check this new behaviour. 