### PR TITLE
Use requested_at in sorting of access requests

### DIFF
--- a/web-app/packages/lib/src/modules/project/components/AccessRequestTableTemplate.vue
+++ b/web-app/packages/lib/src/modules/project/components/AccessRequestTableTemplate.vue
@@ -122,8 +122,8 @@ export default defineComponent({
     return {
       loading: false,
       options: {
-        // Default is order_params=expire ASC
-        sortBy: 'expire',
+        // Default is order_params=requested_at ASC
+        sortBy: 'requested_at',
         sortDesc: false,
         itemsPerPage: 10,
         page: 1

--- a/web-app/packages/lib/src/modules/project/components/ProjectAccessRequests.vue
+++ b/web-app/packages/lib/src/modules/project/components/ProjectAccessRequests.vue
@@ -99,8 +99,8 @@ export default defineComponent({
     return {
       loading: false,
       options: {
-        // Default is order_params=expire ASC
-        sortBy: 'expire',
+        // Default is order_params=requested_at ASC
+        sortBy: 'requested_at',
         sortDesc: false,
         itemsPerPage: 10,
         page: 1

--- a/web-app/packages/lib/src/modules/project/store.ts
+++ b/web-app/packages/lib/src/modules/project/store.ts
@@ -351,7 +351,7 @@ export const useProjectStore = defineStore('projectModule', {
         params: {
           page: 1,
           per_page: 10,
-          order_params: 'expire ASC',
+          order_params: 'requested_at ASC',
           ...payload?.params
         }
       })
@@ -383,7 +383,7 @@ export const useProjectStore = defineStore('projectModule', {
         params: {
           page: 1,
           per_page: 10,
-          order_params: 'expire ASC',
+          order_params: 'requested_at ASC',
           ...payload.params
         }
       })


### PR DESCRIPTION
Unify sorting of access requests using direct db attribute requested_at.