### PR TITLE
Change fetch users logic

### DIFF
--- a/web-app/packages/lib/src/modules/user/store.ts
+++ b/web-app/packages/lib/src/modules/user/store.ts
@@ -498,15 +498,10 @@ export const useUserStore = defineStore('userModule', {
      */
     async getAuthNotProjectUserSearch(params: UserSearchParams) {
       const projectStore = useProjectStore()
-      const access = projectStore.project.access
-      const projectUsers = [
-        ...access.readers,
-        ...access.writers,
-        ...access.owners
-      ]
+      const projectUsers = projectStore.access.map((item) => item.id)
 
       const response = await UserApi.getAuthUserSearch(params)
-      if (access) {
+      if (projectUsers.length) {
         response.data = response.data.filter(
           (item) => !projectUsers.find((id) => id === item.id)
         )


### PR DESCRIPTION
Regarding issue: https://github.com/MerginMaps/server-private/issues/3263.

Users were not displayed in search drop-down on removal without refreshing page due to fetching them from a static array. They were fetched at the beginning and never again. 

After fix they are fetched from an array which gets refreshed on each addition/removal of an user.