### PR TITLE
Add a signal for soft-deleted projects

### DIFF
--- a/server/mergin/sync/commands.py
+++ b/server/mergin/sync/commands.py
@@ -123,9 +123,7 @@ def add_commands(app: Flask):
         if not project:
             click.secho("ERROR: Project does not exist", fg="red", err=True)
             sys.exit(1)
-        project.removed_at = datetime.utcnow()
-        project.removed_by = None
-        db.session.commit()
+        project.schedule_deletion()
         click.secho("Project removed", fg="green")
 
     @project.command()

--- a/server/mergin/sync/models.py
+++ b/server/mergin/sync/models.py
@@ -55,6 +55,7 @@ from .utils import (
 
 Storages = {"local": DiskStorage}
 project_deleted = signal("project_deleted")
+project_soft_deleted = signal("project_soft_deleted")
 project_access_granted = signal("project_access_granted")
 push_finished = signal("push_finished")
 project_version_created = signal("project_version_created")
@@ -285,6 +286,16 @@ class Project(db.Model):
         This time should be used to remove all local copies of the file."""
         initial = timedelta(days=current_app.config["DELETED_PROJECT_EXPIRATION"])
         return initial - (datetime.utcnow() - self.removed_at)
+
+    def schedule_deletion(self, removed_by: int = None):
+        """Schedule project for removal (soft-delete).
+        Sets removed_at so the project is hidden from users but kept in db
+        until a background job permanently deletes it.
+        """
+        self.removed_at = datetime.utcnow()
+        self.removed_by = removed_by
+        db.session.commit()
+        project_soft_deleted.send(self)
 
     def delete(self, removed_by: int = None):
         """Mark project as permanently deleted (but keep in db)

--- a/server/mergin/sync/public_api_controller.py
+++ b/server/mergin/sync/public_api_controller.py
@@ -282,9 +282,7 @@ def delete_project(namespace, project_name):  # noqa: E501
     :rtype: None
     """
     project = require_project(namespace, project_name, ProjectPermissions.Delete)
-    project.removed_at = datetime.utcnow()
-    project.removed_by = current_user.id
-    db.session.commit()
+    project.schedule_deletion(removed_by=current_user.id)
     return NoContent, 200
 
 

--- a/server/mergin/sync/public_api_v2_controller.py
+++ b/server/mergin/sync/public_api_v2_controller.py
@@ -76,9 +76,7 @@ def schedule_delete_project(id):
     rest.
     """
     project = require_project_by_uuid(id, ProjectPermissions.Delete)
-    project.removed_at = datetime.utcnow()
-    project.removed_by = current_user.id
-    db.session.commit()
+    project.schedule_deletion(removed_by=current_user.id)
 
     return NoContent, 204
 

--- a/server/mergin/tests/test_project_controller.py
+++ b/server/mergin/tests/test_project_controller.py
@@ -37,6 +37,7 @@ from ..sync.models import (
     FileHistory,
     PushChangeType,
     ProjectFilePath,
+    project_soft_deleted,
 )
 from ..sync.storages.disk import copy_file as real_copy_file
 from ..sync.files import files_changes_from_upload
@@ -2573,6 +2574,22 @@ def test_signals(client):
         upload_file_to_project(project, "test.txt", client)
         push_finished_mock.assert_called_once()
         project_version_created_mock.assert_called_once()
+
+
+def test_project_soft_delete(client):
+    """project.schedule_deletion() sets removed_at/removed_by and fires project_soft_deleted signal"""
+    workspace = create_workspace()
+    user = User.query.filter_by(username="mergin").first()
+    project = create_project("remove-test", workspace, user)
+
+    with patch("mergin.sync.models.project_soft_deleted.send") as signal_mock:
+        project.schedule_deletion(removed_by=user.id)
+        signal_mock.assert_called_once_with(project)
+
+    assert project.removed_at is not None
+    assert project.removed_by == user.id
+    # project storage params is still present (soft delete)
+    assert project.storage_params is not None
 
 
 def test_filepath_manipulation(client):


### PR DESCRIPTION
Other components can listen on signal and add custom handling.
Also soft-delete action was moved to single method instead of being scattered in code.
