### PR TITLE
Suppress focus halo on icon action buttons after mouse click

### DIFF
--- a/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/_extensions.scss
+++ b/web-app/packages/lib/src/assets/sass/themes/mm-theme-light/_extensions.scss
@@ -122,6 +122,11 @@ img {
 .p-button.icon-action-btn {
   color: map-get($colors, 'forest');
 
+  // Suppress the focus halo after a mouse click
+  &:focus:not(:focus-visible) {
+    box-shadow: none;
+  }
+
   &:not(:disabled):hover {
     background: map-get($colors, 'light-green');
     color: map-get($colors, 'forest');


### PR DESCRIPTION
This adds a one-line CSS rule on \`.icon-action-btn\` to drop the focus ring on mouse interaction while preserving it for keyboard navigation (accessibility).