### PR TITLE
Display whitespaces in delete dialogs

### DIFF
--- a/web-app/packages/lib/src/modules/dialog/components/ConfirmDialog.vue
+++ b/web-app/packages/lib/src/modules/dialog/components/ConfirmDialog.vue
@@ -9,7 +9,9 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
     <img :src="logoSrc" alt="Cover for confirm dialog" />
     <span class="text-color-forest title-t1">{{ text }}</span>
     <span class="paragraph-p5 opacity-80">{{ description }}</span>
-    <span v-if="hint" class="title-t2 my-2">{{ hint }}</span>
+    <span v-if="hint" class="title-t2 my-2" style="white-space: pre-wrap">{{
+      hint
+    }}</span>
     <div class="flex flex-column gap-3 w-full">
       <span
         v-if="confirmField"


### PR DESCRIPTION
Fixes https://github.com/MerginMaps/server-private/issues/3430

The default behavior of html elements is to collapse more whitespaces in a row.
This fixes displaying whitespaces only in closing dialogues (user account, workspace, project), as it is the only place in the web app where users need to write the project/workspace name, and even copy-pasting does not work when whitespaces are collapsed.
Other places where names are displayed keep the default behaviour. 

<img height="500" alt="image" src="https://github.com/user-attachments/assets/3584349e-166c-4ecc-b330-b70de21c5008" />

The workspace name in the top right corner is displayed differently..
<img height="500" alt="image" src="https://github.com/user-attachments/assets/3e78be9e-fbd3-476c-ae78-c2aabdfd7798" />
