### PR TITLE
Enable sent events

### DIFF
--- a/server/mergin/celery.py
+++ b/server/mergin/celery.py
@@ -68,6 +68,7 @@ def configure_celery(celery: Celery, app: Flask, packages: List[str]):
     celery.conf.update(app.config)
     celery.conf.update(
         task_acks_late=Configuration.CELERY_ACKS_LATE,
+        task_send_sent_event=Configuration.CELERY_TASK_SEND_SENT_EVENT,
         worker_concurrency=Configuration.CELERYD_CONCURRENCY,
         worker_prefetch_multiplier=Configuration.CELERYD_PREFETCH_MULTIPLIER,
     )

--- a/server/mergin/celery.py
+++ b/server/mergin/celery.py
@@ -11,7 +11,6 @@ from smtplib import SMTPException, SMTPServerDisconnected
 from .config import Configuration
 from .app import mail
 
-
 # create on flask app independent object
 # we need this for defining tasks, and celery is then configured in run_celery.py
 celery = Celery(
@@ -68,7 +67,7 @@ def configure_celery(celery: Celery, app: Flask, packages: List[str]):
     celery.conf.update(app.config)
     celery.conf.update(
         task_acks_late=Configuration.CELERY_ACKS_LATE,
-        task_send_sent_event=Configuration.CELERY_TASK_SEND_SENT_EVENT,
+        task_send_sent_event=Configuration.CELERY_SEND_TASK_SENT_EVENT,
         worker_concurrency=Configuration.CELERYD_CONCURRENCY,
         worker_prefetch_multiplier=Configuration.CELERYD_PREFETCH_MULTIPLIER,
     )

--- a/server/mergin/config.py
+++ b/server/mergin/config.py
@@ -69,6 +69,11 @@ class Configuration(object):
         "CELERY_RESULT_BACKEND_TRANSPORT_OPTIONS", default="{}", cast=eval
     )
     CELERY_ACKS_LATE = config("CELERY_ACKS_LATE", default=False, cast=bool)
+    # send a task-sent event when a task is published so that monitoring tools
+    # (e.g. celery-exporter) can report the queue name, including for failed tasks
+    CELERY_TASK_SEND_SENT_EVENT = config(
+        "CELERY_TASK_SEND_SENT_EVENT", default=False, cast=bool
+    )
     CELERYD_CONCURRENCY = config("CELERYD_CONCURRENCY", default=1, cast=int)
     CELERYD_PREFETCH_MULTIPLIER = config(
         "CELERYD_PREFETCH_MULTIPLIER", default=4, cast=int

--- a/server/mergin/config.py
+++ b/server/mergin/config.py
@@ -71,8 +71,8 @@ class Configuration(object):
     CELERY_ACKS_LATE = config("CELERY_ACKS_LATE", default=False, cast=bool)
     # send a task-sent event when a task is published so that monitoring tools
     # (e.g. celery-exporter) can report the queue name, including for failed tasks
-    CELERY_TASK_SEND_SENT_EVENT = config(
-        "CELERY_TASK_SEND_SENT_EVENT", default=False, cast=bool
+    CELERY_SEND_TASK_SENT_EVENT = config(
+        "CELERY_SEND_TASK_SENT_EVENT", default=False, cast=bool
     )
     CELERYD_CONCURRENCY = config("CELERYD_CONCURRENCY", default=1, cast=int)
     CELERYD_PREFETCH_MULTIPLIER = config(


### PR DESCRIPTION
Resolves https://github.com/MerginMaps/server-private/issues/3449

Based on: https://github.com/danihodovic/celery-exporter#usage
- sent events configuration to see which queue was failed revoked etc.
- this could improve celery metrics