### PR TITLE
Apply default_version() when version is empty string

### DIFF
--- a/server/mergin/config.py
+++ b/server/mergin/config.py
@@ -104,7 +104,7 @@ class Configuration(object):
         "ENABLE_SUPERADMIN_ASSIGNMENT", default=True, cast=bool
     )
     # backend version
-    VERSION = config("VERSION", default=get_version())
+    VERSION = config("VERSION", default="") or get_version()
     SERVER_TYPE = config("SERVER_TYPE", default="ce")
 
     # whether to run flask app with gevent worker type in gunicorn


### PR DESCRIPTION
The version variable is correctly populated for release builds, but breaks cd.dev: in the SaaS build workflow_dispatch path (non-release), VERSION is set to an empty string, and the default=get_version() fallback never fires and /config reports an empty version. That breaks client feature checks of the supported server version.


<img width="518" height="149" alt="image" src="https://github.com/user-attachments/assets/d662e078-4b6f-4f1e-b4f5-e7e6e8e14e32" />
