### PR TITLE
Grant the project creator an owner role on creation

### DIFF
--- a/LICENSES/CLA-signed-list.md
+++ b/LICENSES/CLA-signed-list.md
@@ -5,6 +5,7 @@ A/ You have read and agree to the individual CLA: https://merginmaps.com/license
 * `alhirzel`, 20th December 2023
 * `uprel`, 18th March 2024
 * `enockseth`, 5th May 2025
+* `silentsudo-io`, 9th August 2026
 
 B/ I have read and agree with entity CLA for my company: https://merginmaps.com/licenses/entity-cla
 

--- a/server/mergin/sync/public_api_controller.py
+++ b/server/mergin/sync/public_api_controller.py
@@ -266,6 +266,10 @@ def add_project(namespace):  # noqa: E501
 
         db.session.add(p)
         db.session.add(version)
+        # Grant the creator ownership of the project they have just created.
+        # Without this the project has no roles at all, so it cannot be shared,
+        # and under GLOBAL_ADMIN=True its own creator cannot see it.
+        p.set_role(current_user.id, ProjectRole.OWNER)
         db.session.commit()
         project_version_created.send(version)
         return NoContent, 200
@@ -1296,6 +1300,9 @@ def clone_project(namespace, project_name):  # noqa: E501
         device_id,
     )
     db.session.add(project_version)
+    # Same as in add_project: the creator of a cloned project must hold a role
+    # on it, otherwise the clone cannot be shared or, for a non-superuser, seen.
+    p.set_role(current_user.id, ProjectRole.OWNER)
     db.session.commit()
     project_version_created.send(project_version)
     return NoContent, 200


### PR DESCRIPTION
Fixes #659.

## The problem

`add_project()` never grants the creator a role, so a new project ends up with **no rows in `project_member` at all**. Two consequences:

1. **Sharing is broken.** With no roles on the project, the Collaborators page has nothing to work with and the owner cannot add anyone — including themselves. This was the presenting symptom on our self-hosted CE server.
2. **With `GLOBAL_ADMIN=True`, the creator cannot see their own project.** `GlobalWorkspaceHandler.get_user_role()` returns `GUEST` for non-superusers, and a `GUEST` reaches a project only via `project_member` or `Project.public`. So `projects_query(ProjectPermissions.Read)` filters the project out *before* the `flag=created` creator test is reached — `GET /v1/project/paginated?flag=created` returns `count=0` for the user who just created it.

## The change

`p.set_role(current_user.id, ProjectRole.OWNER)` before the commit, in **both** creation paths:

* `add_project()`
* `clone_project()` — same omission, same effect on a cloned project

`ProjectRole` was already imported in the module, so this adds no imports. `set_role()` appends to the `project_users` relationship, which cascades on commit, so it works on the still-pending `Project`.

## Notes for reviewers

* **`set_role()` fires `project_access_granted`.** It will now fire for the creator on every project creation. That seemed semantically right — access *was* granted — but if you would rather not emit it for the creator, say so and I will restructure.
* **Existing servers stay broken without a migration.** Projects already created carry no `project_member` rows. A data migration granting `owner` to `creator_id` where a project has no members would repair them. Happy to add one to this PR if you want it here rather than separately.
* I have not added a test. If you would like one, point me at the preferred place and I will follow up.

## Verified against

Reproduced on self-hosted CE, backend image `2025.7.3`, single global workspace, `GLOBAL_*` all at defaults. Two projects created by two different users via two different paths (web UI and REST API) both landed with zero member rows. `add_project()` is structurally unchanged from `2025.7.3` through `2026.6.2`, so this affects all of them.

CLA: I have added `silentsudo-io` to the individual CLA list in `LICENSES/CLA-signed-list.md` in this PR.
