### PR TITLE
Update slack community links and readme

### DIFF
--- a/LICENSES/CLA-signed-list.md
+++ b/LICENSES/CLA-signed-list.md
@@ -23,3 +23,4 @@ C/ My company has custom contribution contract with Lutra Consulting Ltd. or I a
 * fernandinand, 13th March 2025
 * wonder-sk, 9th February 2026
 * xkello, 26th January 2026
+* gabriel-bolbotina, 18th August 2026

--- a/README.md
+++ b/README.md
@@ -84,10 +84,8 @@ If you'd like to contribute and improve the documentation, visit https://github.
 ## Get in touch
 
 If you need support, a custom deployment, extending the service capabilities and new features do not hesitate to contact us on info@lutraconsulting.co.uk
-<br><br>
 
-<div><img align="left" width="45" height="45" src="https://raw.githubusercontent.com/MerginMaps/docs/main/src/public/slack.svg"><a href="https://merginmaps.com/community/join">Join our community chat</a><br/>and ask questions!</div>
-<br>
+<a href="https://community.merginmaps.com">Join our community</a> and ask questions!
 
 ## Developers
 

--- a/web-app/packages/lib/.env
+++ b/web-app/packages/lib/.env
@@ -1,1 +1,1 @@
-VITE_VUE_APP_JOIN_COMMUNITY_LINK=https://merginmaps.com/community/join
+VITE_VUE_APP_COMMUNITY_LINK=https://community.merginmaps.com

--- a/web-app/packages/lib/src/env.d.ts
+++ b/web-app/packages/lib/src/env.d.ts
@@ -5,7 +5,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_VUE_APP_JOIN_COMMUNITY_LINK: string
+  readonly VITE_VUE_APP_COMMUNITY_LINK: string
 }
 
 interface ImportMeta {

--- a/web-app/packages/lib/src/modules/layout/components/AppHeaderTemplate.vue
+++ b/web-app/packages/lib/src/modules/layout/components/AppHeaderTemplate.vue
@@ -242,8 +242,8 @@ export default defineComponent({
           target: '_blank'
         },
         {
-          label: 'Community chat',
-          url: import.meta.env.VITE_VUE_APP_JOIN_COMMUNITY_LINK,
+          label: 'Community',
+          url: import.meta.env.VITE_VUE_APP_COMMUNITY_LINK,
           target: '_blank'
         },
         ...(this.helpMenuItems ?? [])


### PR DESCRIPTION
Since we are moving away from the Slack community workspace to our own platform, I made the following changes:
- Updated the readme file by removing slack and changing the link
- Updated the link to the community